### PR TITLE
command line option to prepend track number to file names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Adds parameter `--prefix`  to enable prepending of track number in playlist to have a filename sorted output when downloading playlists ([@alpsayin](https://github.com/alpsayin)) (#622)
 ### Added
 - Added `--no-remove-original-file` ([@NightMachinary](https://github.com/NightMachinary)) (#580)
 - Added leading Zeros in `track_number` for correct sorting ([@Dsujan](https://github.com/Dsujan)) (#592)

--- a/spotdl/downloader.py
+++ b/spotdl/downloader.py
@@ -225,7 +225,9 @@ class ListDownloader:
             except (urllib.request.URLError, TypeError, IOError) as e:
                 # detect network problems
                 self._cleanup(raw_song, e)
-                self.failed_tracks[len(self.tracks)-1] = number
+                log.warning(f'Keeping track of track #{number} in {len(self.tracks)-1}')
+                # since the enumeration starts from 0, we store not len-1 but len to avoid skipping tracks
+                self.failed_tracks[len(self.tracks)] = number
                 # TODO: remove this sleep once #397 is fixed
                 # wait 0.5 sec to avoid infinite looping
                 time.sleep(0.5)

--- a/spotdl/downloader.py
+++ b/spotdl/downloader.py
@@ -215,8 +215,11 @@ class ListDownloader:
             print("")
             try:
                 if number in self.failed_tracks:
-                    number = self.failed_tracks[number]
+                    log.info(f'Track #{number} is a retry of #{self.failed_tracks[number]} - {raw_song}')
+                    # below triangle swap ensures original track number is preserved even if multiple consecutive errors happen 
+                    orig_number = self.failed_tracks[number]
                     del self.failed_tracks[number]
+                    number = orig_number
                 track_dl = Downloader(raw_song, number=number)
                 track_dl.download_single()
             except (urllib.request.URLError, TypeError, IOError) as e:

--- a/spotdl/downloader.py
+++ b/spotdl/downloader.py
@@ -225,7 +225,7 @@ class ListDownloader:
             except (urllib.request.URLError, TypeError, IOError) as e:
                 # detect network problems
                 self._cleanup(raw_song, e)
-                log.warning(f'Keeping track of track #{number} in {len(self.tracks)-1}')
+                log.warning(f'Keeping track of track #{number} in {len(self.tracks)}')
                 # since the enumeration starts from 0, we store not len-1 but len to avoid skipping tracks
                 self.failed_tracks[len(self.tracks)] = number
                 # TODO: remove this sleep once #397 is fixed

--- a/spotdl/downloader.py
+++ b/spotdl/downloader.py
@@ -110,7 +110,10 @@ class Downloader:
         log.info("{} ({})".format(youtube_title, self.content.watchv_url))
 
         # generate file name of the song to download
-        songname = self.refine_songname(self.content.title)
+        prefix = ''
+        if const.args.prefix:
+            prefix = f'{self.number} - '
+        songname = self.refine_songname(self.content.title, prefix=prefix)
 
         if const.args.dry_run:
             return
@@ -156,13 +159,14 @@ class Downloader:
             log.info("Found no metadata. Skipping the download")
             return True
 
-    def refine_songname(self, songname):
+    def refine_songname(self, songname, prefix=''):
         if self.meta_tags is not None:
             refined_songname = internals.format_string(
                 const.args.file_format,
                 self.meta_tags,
                 slugification=True,
                 total_songs=self.total_songs,
+                prefix=prefix,
             )
             log.debug(
                 'Refining songname from "{0}" to "{1}"'.format(

--- a/spotdl/downloader.py
+++ b/spotdl/downloader.py
@@ -112,7 +112,7 @@ class Downloader:
         # generate file name of the song to download
         prefix = ''
         if const.args.prefix:
-            prefix = f'{self.number:03d} - '
+            prefix = '{:03d} - '.format(self.number)
         songname = self.refine_songname(self.content.title, prefix=prefix)
 
         if const.args.dry_run:
@@ -215,7 +215,7 @@ class ListDownloader:
             print("")
             try:
                 if number in self.failed_tracks:
-                    log.info(f'Track #{number} is a retry of #{self.failed_tracks[number]} - {raw_song}')
+                    log.info('Track #{} is a retry of #{} - {}'.format(number, self.failed_tracks[number], raw_song))
                     # below triangle swap ensures original track number is preserved even if multiple consecutive errors happen 
                     orig_number = self.failed_tracks[number]
                     del self.failed_tracks[number]
@@ -225,7 +225,7 @@ class ListDownloader:
             except (urllib.request.URLError, TypeError, IOError) as e:
                 # detect network problems
                 self._cleanup(raw_song, e)
-                log.warning(f'Keeping track of track #{number} in {len(self.tracks)}')
+                log.warning('Keeping track of track #{} in {}'.format(number, len(self.tracks)))
                 # since the enumeration starts from 0, we store not len-1 but len to avoid skipping tracks
                 self.failed_tracks[len(self.tracks)] = number
                 # TODO: remove this sleep once #397 is fixed

--- a/spotdl/downloader.py
+++ b/spotdl/downloader.py
@@ -193,6 +193,7 @@ class ListDownloader:
         self.skip_file = skip_file
         self.write_successful_file = write_successful_file
         self.tracks = internals.get_unique_tracks(self.tracks_file)
+        self.failed_tracks = dict()
 
     def download_list(self):
         """ Download all songs from the list. """
@@ -213,11 +214,15 @@ class ListDownloader:
         for number, raw_song in enumerate(self.tracks, 1):
             print("")
             try:
+                if number in self.failed_tracks:
+                    number = self.failed_tracks[number]
+                    del self.failed_tracks[number]
                 track_dl = Downloader(raw_song, number=number)
                 track_dl.download_single()
             except (urllib.request.URLError, TypeError, IOError) as e:
                 # detect network problems
                 self._cleanup(raw_song, e)
+                self.failed_tracks[number] = len(self.tracks)-1
                 # TODO: remove this sleep once #397 is fixed
                 # wait 0.5 sec to avoid infinite looping
                 time.sleep(0.5)

--- a/spotdl/downloader.py
+++ b/spotdl/downloader.py
@@ -112,7 +112,7 @@ class Downloader:
         # generate file name of the song to download
         prefix = ''
         if const.args.prefix:
-            prefix = f'{self.number} - '
+            prefix = f'{self.number:03d} - '
         songname = self.refine_songname(self.content.title, prefix=prefix)
 
         if const.args.dry_run:

--- a/spotdl/downloader.py
+++ b/spotdl/downloader.py
@@ -222,7 +222,7 @@ class ListDownloader:
             except (urllib.request.URLError, TypeError, IOError) as e:
                 # detect network problems
                 self._cleanup(raw_song, e)
-                self.failed_tracks[number] = len(self.tracks)-1
+                self.failed_tracks[len(self.tracks)-1] = number
                 # TODO: remove this sleep once #397 is fixed
                 # wait 0.5 sec to avoid infinite looping
                 time.sleep(0.5)

--- a/spotdl/handle.py
+++ b/spotdl/handle.py
@@ -30,6 +30,7 @@ default_conf = {
         "dry-run": False,
         "music-videos-only": False,
         "no-spaces": False,
+        "prefix": False,
         "file-format": "{artist} - {track_name}",
         "search-format": "{artist} - {track_name} lyrics",
         "youtube-api-key": None,
@@ -205,6 +206,12 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
         help="file format to save the downloaded track with, each tag "
         "is surrounded by curly braces. Possible formats: "
         "{}".format([internals.formats[x] for x in internals.formats]),
+    )
+    parser.add_argument(
+        "--prefix",
+        default=config["prefix"],
+        help="prepend the track's number to the file name so playlist output is in original order",
+        action="store_true",
     )
     parser.add_argument(
         "--trim-silence",

--- a/spotdl/internals.py
+++ b/spotdl/internals.py
@@ -77,7 +77,7 @@ def is_youtube(raw_song):
 
 
 def format_string(
-    string_format, tags, slugification=False, force_spaces=False, total_songs=0
+    string_format, tags, slugification=False, force_spaces=False, total_songs=0, prefix=''
 ):
     """ Generate a string of the format '[artist] - [song]' for the given spotify song. """
     format_tags = dict(formats)
@@ -114,7 +114,7 @@ def format_string(
     if const.args.no_spaces and not force_spaces:
         string_format = string_format.replace(" ", "_")
 
-    return string_format
+    return prefix+string_format
 
 
 def sanitize_title(title, ok="-_()[]{}"):

--- a/spotdl/internals.py
+++ b/spotdl/internals.py
@@ -114,7 +114,7 @@ def format_string(
     if const.args.no_spaces and not force_spaces:
         string_format = string_format.replace(" ", "_")
 
-    return prefix+string_format
+    return '{}{}'.format(prefix, string_format)
 
 
 def sanitize_title(title, ok="-_()[]{}"):

--- a/spotibash.bash
+++ b/spotibash.bash
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+playlists=(
+            'https://open.spotify.com/playlist/3SnBkikg75VeyH7QRZLN5H?si=9_x3YEppTVKhGkVVaQLUHQ'
+            'https://open.spotify.com/playlist/2o0JEpwxPOMRlPClN9W8Pt?si=EydQB1PLQt-4OrMVpkX_oA'
+            'https://open.spotify.com/playlist/6Ua80N8kOGcnAZNCYVUwP8?si=REeS0jtsS86bAFWPkUp_FA'
+            'https://open.spotify.com/playlist/37i9dQZF1EpmzUbuNBG7yP?si=Go7-Y_VzQ5yOje5JZv61lw'
+            'https://open.spotify.com/playlist/37i9dQZF1E9NTscgVJZuAm?si=WC78B_AERSqnghenSfWonQ'
+            'https://open.spotify.com/playlist/7BgO0Cr0kKECbKQukMmtRd?si=EPv8E43kQFiYPwiVjlNqsw'
+            'https://open.spotify.com/playlist/53RNAtZSEdsfMwrm6hrFZs?si=gEhRZYg-S6GxaIvAQugOUg'
+            )
+
+rm *.txt;
+for i in "${playlists[@]}"
+do 
+    echo "$i";
+    LIST_FILENAME=$(spotdl --playlist $i 2>&1 | grep "INFO" | grep "Writing" | awk '{print $6}')
+    echo "playlist listname $LIST_FILENAME"
+    PL_NAME=(${LIST_FILENAME//./ })
+    echo "playlist name: $PL_NAME"
+    mkdir $PL_NAME;
+    spotdl -ll DEBUG --list $LIST_FILENAME --overwrite skip --trim-silence -f "./$PL_NAME" --prefix -ff "{artist} - {track_name}";
+done;


### PR DESCRIPTION
Adds a "--prefix" command line option (bool) which would in turn output files with 3 -forced- digits of track number in playlist (i.e. "003 - The Airborne Toxic Event - Sometime Around Midnight"). 
- Leading zeroes help mp3 players to keep order if they use lexicographical sort rather than natural (sony :man_shrugging: ).
- I also sorted out keeping track of track number in case of an error by keeping a dictionary to map appended track numbers to original track numbers.
- My test bash script is also included because I dont know how to remove it from PR.

w/love
-Alp