### PR TITLE
add set metadata functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,5 +113,8 @@ venv.bak/
 # mypy
 .mypy_cache/
 
+# pycharm
+.idea
+
 # vscode
 .vscode

--- a/spotdl/handle.py
+++ b/spotdl/handle.py
@@ -126,6 +126,9 @@ def get_arguments(raw_args=None, to_group=True, to_merge=True):
             "--username",
             help="load tracks from user's playlist into <playlist_name>.txt",
         )
+        group.add_argument(
+            "-sm", "--set-metadata", nargs=2, help="set track metadata from url"
+        )
 
     parser.add_argument(
         "--write-m3u",

--- a/spotdl/set_metadata.py
+++ b/spotdl/set_metadata.py
@@ -1,0 +1,34 @@
+import os
+import subprocess
+
+from logzero import logger as log
+
+from spotdl import metadata, const, spotify_tools
+
+
+def create_file(input_file, link):
+    log.info("Get metadata for {}".format(input_file))
+    try:
+        file_ext = '.{}'.format(input_file.split('.')[-1])
+    except Exception as e:
+        file_ext = ''
+
+    meta_tags = spotify_tools.generate_metadata(link)
+    if not meta_tags:
+        log.error("No metadata found.")
+    else:
+        file_name = "{} - {}{}".format(meta_tags["artists"][0]["name"], meta_tags["name"], file_ext)
+        log.info("Create {}".format(file_name))
+        output_file = os.path.join(const.args.folder, file_name)
+        command = (
+                "ffmpeg -y -nostdin -hide_banner -nostats -v panic -i".split()
+                + [input_file]
+                + "-c copy -map_metadata -1 -map 0".split()
+                + [output_file]
+        )
+
+        try:
+            subprocess.call(command)
+            metadata.embed(output_file, meta_tags)
+        except Exception as e:
+            log.error(str(e))

--- a/spotdl/spotdl.py
+++ b/spotdl/spotdl.py
@@ -13,6 +13,7 @@ from spotdl import internals
 from spotdl import spotify_tools
 from spotdl import youtube_tools
 from spotdl import downloader
+from spotdl import set_metadata
 
 
 def debug_sys_info():
@@ -54,6 +55,8 @@ def match_args():
         spotify_tools.write_user_playlist(
             username=const.args.username, text_file=const.args.write_to
         )
+    elif const.args.set_metadata:
+        set_metadata.create_file(*const.args.set_metadata)
 
 
 def main():


### PR DESCRIPTION
#### why?!
I was in a situation where I already had a high-quality version of a song, but with incorrect metadata which i couldn't find even the same version on youtube, so added `set_metadata` option to correct file metadata.

#### how?
it uses `spotify_tools.generate_metadata()` to get metadata and `ffmpeg` to remove current metadata of file without changing file encoding ( everything was fine without `ffmpeg`, just previous `cover art` was there even after resetting file metadata, therefore `ffmpeg` used to remove them ) and `metadata.embed` to set new data.

#### note
this pull request does not change any previous functionalities. this code may not match the desired style/principles of this project, so I'm looking forward to reviews.