### PR TITLE
Apple music playlists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 The release dates mentioned follow the format `DD-MM-YYYY`.
 
 ## [Unreleased]
+## Added
+- Support for Apple Music playlists (#728)
 
 ## [2.2.2] - 28-07-2020
 ## Fixed

--- a/spotdl/command_line/core.py
+++ b/spotdl/command_line/core.py
@@ -1,4 +1,3 @@
-from spotdl.helpers.apple_music import fetch_playlist
 from spotdl.metadata.providers import ProviderSpotify
 import spotdl.metadata
 
@@ -15,6 +14,7 @@ from spotdl.command_line.exceptions import NoYouTubeVideoMatchError
 from spotdl.metadata_search import MetadataSearch
 
 from spotdl.helpers.spotify import SpotifyHelpers
+from spotdl.helpers.apple_music import fetch_playlist
 from spotdl.command_line.arguments import ArgumentHandler
 import spotdl.helpers.exceptions
 
@@ -161,7 +161,7 @@ class Spotdl:
                 spotify_tools.write_playlist_tracks(playlist, self.arguments["write_to"])
 
             if "music.apple.com" in self.arguments["playlist"]:
-                logger.debug('Playlist not found on Spotify. Fetching from Apple Music')
+                logger.info('Playlist not found on Spotify. Fetching from Apple Music')
                 try:
                     playlist = fetch_playlist(self.arguments["playlist"])
                 except spotdl.helpers.exceptions.AppleMusicPlaylistNotFoundError:

--- a/spotdl/helpers/apple_music.py
+++ b/spotdl/helpers/apple_music.py
@@ -1,0 +1,40 @@
+from urllib import request, error
+from bs4 import BeautifulSoup
+import logging
+import spotdl.helpers.exceptions
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_playlist(playlist_uri):
+    try:
+        content = request.urlopen(playlist_uri)
+    except error.URLError as e:
+        message = 'Error opening requested URL: {reason}'.format(reason=e.reason)
+        logger.error(message)
+        raise spotdl.helpers.exceptions.AppleMusicPlaylistNotFoundError
+    else:
+        playlist_html = BeautifulSoup(content.read(), 'html.parser')
+        playlist = {
+            'items': [],
+            'name': playlist_html.find("h1", {"class": "product-name"}).text.strip(),
+            'creator': playlist_html.find("h2", {"class": "product-creator"}).text.strip()
+        }
+
+        logger.debug(f'Fetching list: "{playlist["name"]} by {playlist["creator"]}"')
+
+        songs = playlist_html.findAll("div", {"class": "song"})
+        if not songs:
+            logger.error(f'Playlist {playlist_uri} is either empty or some other error occurred.')
+            raise spotdl.helpers.exceptions.AppleMusicPlaylistNotFoundError
+        for song in songs:
+            try:
+                song_dict = {
+                    'name': song.find('div', attrs={'class': 'song-name'}).text.strip(),
+                    'artists': [song.find('a', attrs={'class': 'dt-link-to'}).text.strip()]
+                }
+            except AttributeError:
+                logger.warning('Song data not found in html. Skipping')
+                pass
+            else:
+                playlist['items'].append(song_dict)

--- a/spotdl/helpers/apple_music.py
+++ b/spotdl/helpers/apple_music.py
@@ -7,14 +7,29 @@ logger = logging.getLogger(__name__)
 
 
 def fetch_playlist(playlist_uri):
+    """
+    Helper function that gets html data from the given music.apple.com url and parses
+    this data into the dictionary format used by the Spotify API
+
+    Parameters
+    ----------
+    playlist_uri: `str`
+        The Apple Music playlist URL
+
+    Returns
+    -------
+    playlist: `dict`
+        The playlist data in the Spotify dictionary format
+    """
     try:
         content = request.urlopen(playlist_uri)
     except error.URLError as e:
-        message = 'Error opening requested URL: {reason}'.format(reason=e.reason)
+        message = 'Error opening requested URL ({url}): {reason}'.format(reason=e.reason, url=playlist_uri)
         logger.error(message)
         raise spotdl.helpers.exceptions.AppleMusicPlaylistNotFoundError
     else:
         playlist_html = BeautifulSoup(content.read(), 'html.parser')
+
         playlist = {
             'tracks': {
                 "items": [],
@@ -26,11 +41,12 @@ def fetch_playlist(playlist_uri):
         }
 
         logger.info(f'Fetching list: "{playlist["name"]} by {playlist["creator"]}" from Apple Music')
-
         songs = playlist_html.findAll("div", {"class": "song"})
+
         if not songs:
             logger.error(f'Playlist {playlist_uri} is either empty or some other error occurred.')
             raise spotdl.helpers.exceptions.AppleMusicPlaylistNotFoundError
+
         playlist['tracks']['total'] = len(songs)
         for song in songs:
             try:

--- a/spotdl/helpers/apple_music.py
+++ b/spotdl/helpers/apple_music.py
@@ -16,25 +16,33 @@ def fetch_playlist(playlist_uri):
     else:
         playlist_html = BeautifulSoup(content.read(), 'html.parser')
         playlist = {
-            'items': [],
+            'tracks': {
+                "items": [],
+                "total": 0,
+                "next": None
+            },
             'name': playlist_html.find("h1", {"class": "product-name"}).text.strip(),
             'creator': playlist_html.find("h2", {"class": "product-creator"}).text.strip()
         }
 
-        logger.debug(f'Fetching list: "{playlist["name"]} by {playlist["creator"]}"')
+        logger.info(f'Fetching list: "{playlist["name"]} by {playlist["creator"]}" from Apple Music')
 
         songs = playlist_html.findAll("div", {"class": "song"})
         if not songs:
             logger.error(f'Playlist {playlist_uri} is either empty or some other error occurred.')
             raise spotdl.helpers.exceptions.AppleMusicPlaylistNotFoundError
+        playlist['tracks']['total'] = len(songs)
         for song in songs:
             try:
                 song_dict = {
                     'name': song.find('div', attrs={'class': 'song-name'}).text.strip(),
-                    'artists': [song.find('a', attrs={'class': 'dt-link-to'}).text.strip()]
+                    'artists': [
+                        {'name': song.find('a', attrs={'class': 'dt-link-to'}).text.strip()}
+                    ]
                 }
             except AttributeError:
                 logger.warning('Song data not found in html. Skipping')
                 pass
             else:
-                playlist['items'].append(song_dict)
+                playlist['tracks']['items'].append(song_dict)
+    return playlist

--- a/spotdl/helpers/exceptions.py
+++ b/spotdl/helpers/exceptions.py
@@ -33,6 +33,13 @@ class SpotifyPlaylistNotFoundError(PlaylistNotFoundError):
         super().__init__(message)
 
 
+class AppleMusicPlaylistNotFoundError(PlaylistNotFoundError):
+    __module__ = Exception.__module__
+
+    def __init__(self, message=None):
+        super().__init__(message)
+
+
 class SpotifyAlbumNotFoundError(AlbumNotFoundError):
     __module__ = Exception.__module__
 

--- a/spotdl/helpers/spotify.py
+++ b/spotdl/helpers/spotify.py
@@ -270,7 +270,9 @@ class SpotifyHelpers:
                         track_urls.append(track_url)
                     except KeyError:
                         file_io.write(
-                            '{0} by {1}'.format(track["name"], track["artists"][0]["name"])
+                            '{0} by {1}\n'.format(
+                                track["name"],
+                                track["artists"][0]["name"])
                         )
 
                 # 1 page = 50 results
@@ -287,7 +289,7 @@ class SpotifyHelpers:
             file_out = sys.stdout
             track_urls = writer(tracks, file_out)
         else:
-            with open(target_path, "a") as file_out:
+            with open(target_path, "a", encoding='utf-8') as file_out:
                 track_urls = writer(tracks, file_out)
         return track_urls
 

--- a/spotdl/helpers/spotify.py
+++ b/spotdl/helpers/spotify.py
@@ -269,13 +269,10 @@ class SpotifyHelpers:
                         file_io.write(track_url + "\n")
                         track_urls.append(track_url)
                     except KeyError:
-                        # FIXME: Write "{artist} - {name}" instead of Spotify URI for
-                        #        "local only" tracks.
-                        logger.warning(
-                            'Skipping track "{0}" by "{1}" (local only?)'.format(
-                                track["name"], track["artists"][0]["name"]
-                            )
+                        file_io.write(
+                            '{0} by {1}'.format(track["name"], track["artists"][0]["name"])
                         )
+
                 # 1 page = 50 results
                 # check if there are more pages
                 if tracks["next"]:


### PR DESCRIPTION
This is a quick implementation of the feature requested in #728 . This allows users to call
`spotdl --playlist {apple_music_playlist_url}` 
and then use the resulting file in the same way they would when calling it for a spotify playlist.