### PR TITLE
Fix possible "IndexError" in "best_matching_lyric_url_from_query"

### DIFF
--- a/spotdl/lyrics/providers/genius.py
+++ b/spotdl/lyrics/providers/genius.py
@@ -115,7 +115,10 @@ class Genius(LyricBase):
 
         lyric_url = None
         for section in metadata["response"]["sections"]:
-            result = section["hits"][0]["result"]
+            try:
+                result = section["hits"][0]["result"]
+            except IndexError:
+                continue
             try:
                 lyric_url = result["path"]
                 break


### PR DESCRIPTION
Not sure about the code-style your prefer (checking the length with `if` instead of `try / catch`, using `else:` instead of `continue`). Let me know if you want me to change it.

Fixes #807.