### PR TITLE
replace fuzzywuzzy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,12 @@ setup(
     version = '3.1.0',
 
     install_requires = [
-        'fuzzywuzzy',
         'spotipy',
         'pytube3',
         'tqdm',
+        'rapidfuzz'
         'requests',
         'mutagen',
-        'python-Levenshtein-wheels',
     ],
 
     description="Downloads Spotify music from Youtube with metadata and album art",


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy

Since it is written in C++14 on Windows it requires the C++ Redistributable 2015 to be installed (or newer versions like 2019, that include the 2015 version automatically)