### PR TITLE
add missing comma

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         'spotipy',
         'pytube3',
         'tqdm',
-        'rapidfuzz'
+        'rapidfuzz',
         'requests',
         'mutagen',
     ],


### PR DESCRIPTION
@Mikhail-Zex There is a comma missing in install_requires since #858, which breaks the installation

