### PR TITLE
Changed Audio encoding + add spotifyURL to metadata

### DIFF
--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -132,10 +132,6 @@ def download_song(songObj: SongObj, displayManager: DisplayManager = None,
     #! intergrated loudness target (I) set to -17, using values lower than -15
     #! causes 'pumping' i.e. rhythmic variation in loudness that should not
     #! exist -loud parts exaggerate, soft parts left alone.
-    #! 
-    #! dynaudnorm applies dynamic non-linear RMS based normalization, this is what
-    #! actually normalized the audio. The loudnorm filter just makes the apparent
-    #! loudness constant
     #!
     #! apad=pad_dur=2 adds 2 seconds of silence toward the end of the track, this is
     #! done because the loudnorm filter clips/cuts/deletes the last 1-2 seconds on
@@ -148,7 +144,7 @@ def download_song(songObj: SongObj, displayManager: DisplayManager = None,
     #! sampled length of songs matches the actual length (i.e. a 5 min song won't display
     #! as 47 seconds long in your music player, yeah that was an issue earlier.)
 
-    command = 'ffmpeg -v quiet -y -i "%s" -acodec libmp3lame -abr true -af "apad=pad_dur=2, dynaudnorm, loudnorm=I=-17" "%s"'
+    command = 'ffmpeg -v quiet -y -i "%s" -acodec libmp3lame -abr true -af loudnorm=I=-17 "%s"'
     formattedCommand = command % (downloadedFilePath, convertedFilePath)
 
     run_in_shell(formattedCommand)
@@ -199,6 +195,10 @@ def download_song(songObj: SongObj, displayManager: DisplayManager = None,
     #! album release date (to what ever precision available)
     audioFile['date']         = songObj.get_album_release()
     audioFile['originaldate'] = songObj.get_album_release()
+
+    #! spotify link: in case you wanna re-download your whole offline library,
+    #! you can just read the links from the tags and redownload the songs.
+    audioFile['website'] = songObj.get_spotify_link()
 
     #! save as both ID3 v2.3 & v2.4 as v2.3 isn't fully features and
     #! windows doesn't support v2.4 until later versions of Win10

--- a/spotdl/search/songObj.py
+++ b/spotdl/search/songObj.py
@@ -102,6 +102,9 @@ class SongObj():
     def get_youtube_link(self) -> str:
         return self.__youtubeLink
 
+    def get_spotify_link(self) -> str:
+        return 'http://open.spotify.com/track/' + self.__rawTrackMeta['id']
+
     #! Song Details:
     
     #! 1. Name


### PR DESCRIPTION
1. Dynamic audio normalization flattens the sound and kill the music, got rid of it.

2. In case you wanna re-download your music library, you can just pick up the songURL's from the metadata.