### PR TITLE
Updated README File

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ You can chain up download tasks by seperating them with spaces:
 Spotdl downloads up to 4 songs in parallel - try to download albums and playlists instead of
 tracks for more speed.
 
+# Note
+
+The availability of YouTube Music in your country is important for spotDL to work since we use YouTube Music to filter out our search results.
+To check if YouTube Music is available in your country, visit [YouTube Music](https://music.youtube.com).
+
 # Thanks for developing the v3.0.1
 1. [@ritiek](https://github.com/ritiek) for creating and maintaining spotDL for 4 years
 2. [@rocketinventor](https://github.com/rocketinventor) for figuring out the YouTube Music querying


### PR DESCRIPTION
Hi, there are many issues opened relating no match being found on youtube. For example,

`The command runs, but it gives error:`

`Fetching Song...`

`Skipping Wrecking Ball (https://open.spotify.com/track/2vwlzO0Qp8kfEtzTsCXfyE?si=MWIfZua9SnqnSaWro-prrQ) as no match could be found on youtube`

`0%| |ETA: ?, ~min/song`

This problem was pointed out to me by @Mikhail-Zex and he told me to open a PR so i added a NOTE in README.md file relating the availability of YouTube Music in the user's country for spotDL to work.