### PR TITLE
Speed Up of spotdl objects gathering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Spotdl dev related testing files
 *.log
 *.spotdlTrackingFile
+*.spotdlKey
 *.mp3
 *.mp4
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ⚠ We are dropping active development of spotDL v2. No focused efforts will be made to resolve v2
 specific issues.
 
-⚠ We are actively looking for Contributors/Organization Members for all projects under development. 
+⚠ We are actively looking for Contributors/Organization Members for all projects under development.
 If interested, see [#857](https://github.com/spotDL/spotify-downloader/issues/857)
 
 ⚠ There are a few feature requests we'd like the community to vote on. Do voice your support for features you'd like.
@@ -47,7 +47,7 @@ you use spotDL v3 and open issues for problems that you come across.
     ```
     $pip install https://github.com/spotDL/spotify-downloader/archive/master.zip
     ```
-        
+
 3. Voila !
 
 # How to use (instructions for v3)
@@ -57,22 +57,27 @@ To download a song run,
     spotdl https://open.spotify.com/track/08mG3Y1vljYA6bvDt4Wqkj?si=SxezdxmlTx-CaVoucHmrUA
 
 To download an album run,
-    
+
     # spotdl $albumUrl
     spotdl https://open.spotify.com/album/2YMWspDGtbDgYULXvVQFM6?si=gF5dOQm8QUSo-NdZVsFjAQ
 
 To download a playlist run,
-    
+
     # spotdl $playlistUrl
     spotdl https://open.spotify.com/playlist/37i9dQZF1DWXhcuQw7KIeM?si=xubKHEBESM27RqGkqoXzgQ
 
+To download an artist's songs run,
+
+    # spotdl $artistUrl
+    spotdl https://open.spotify.com/artist/6fOMl44jA4Sp5b9PpYCkzz
+
 To search for and download a song (not very accurate) run,
-    
+
     # spotdl $songQuery
     spotdl 'The HU - Sugaan Essenna'
 
 To resume a failed/incomplete download run,
-    
+
 -   ```
     # spotdl $pathToTrackingFile
     spotdl 'Sugaan Essenna.spotdlTrackingFile'
@@ -82,7 +87,7 @@ To resume a failed/incomplete download run,
     download completion
 
 You can chain up download tasks by seperating them with spaces:
-    
+
     # spotdl $songQuery1 $albumUrl $songQuery2 ... (order does not matter)
     spotdl 'The Hu - Sugaan Essenna' https://open.spotify.com/playlist/37i9dQZF1DWXhcuQw7KIeM?si=xubKHEBESM27RqGkqoXzgQ ...
 

--- a/spotdl/__main__.py
+++ b/spotdl/__main__.py
@@ -3,7 +3,7 @@ from spotdl.search.spotifyClient import initialize
 from sys import argv as cliArgs
 
 #! Song Search from different start points
-from spotdl.search.utils import get_playlist_tracks, get_album_tracks, search_for_song, get_artist_tracks
+from spotdl.search.utils import get_playlist_tracks, get_album_tracks, search_for_song, get_artist_tracks, get_artist_discography
 from spotdl.search.songObj import SongObj
 
 #! The actual download stuff
@@ -105,7 +105,8 @@ def console_entry_point():
 
         elif ('open.spotify.com' in request and 'artist' in request) or 'spotify:artist:' in request:
             print('Fetching Artist\'s Tracks...')
-            songObjList = get_artist_tracks(request)
+            # songObjList = get_artist_tracks(request, isPrimaryArtist=False)
+            songObjList = get_artist_discography(request)
 
             downloader.download_multiple_songs(songObjList)
 

--- a/spotdl/__main__.py
+++ b/spotdl/__main__.py
@@ -105,8 +105,8 @@ def console_entry_point():
 
         elif ('open.spotify.com' in request and 'artist' in request) or 'spotify:artist:' in request:
             print('Fetching Artist\'s Tracks...')
-            # songObjList = get_artist_tracks(request, isPrimaryArtist=False)
-            songObjList = get_artist_discography(request)
+            songObjList = get_artist_tracks(request, isPrimaryArtistOnly=False)
+            # songObjList = get_artist_discography(request)
 
             downloader.download_multiple_songs(songObjList)
 

--- a/spotdl/__main__.py
+++ b/spotdl/__main__.py
@@ -3,7 +3,7 @@ from spotdl.search.spotifyClient import initialize
 from sys import argv as cliArgs
 
 #! Song Search from different start points
-from spotdl.search.utils import get_playlist_tracks, get_album_tracks, search_for_song, get_artist_tracks
+from spotdl.search.utils import get_playlist_tracks, get_album_tracks, search_for_song, get_artist_tracks, get_artist_albums, get_album_tracks_only_from_artist
 from spotdl.search.songObj import SongObj
 
 #! The actual download stuff
@@ -106,6 +106,20 @@ def console_entry_point():
         elif ('open.spotify.com' in request and 'artist' in request) or 'spotify:artist:' in request:
             print('Fetching Artist\'s Tracks...')
             songObjList = get_artist_tracks(request)
+            
+            # artistAlbums = get_artist_albums(request)
+            # artistTracks = []
+
+
+
+            # for album in artistAlbums:
+            #     print('looking deeper into ', album)
+            #     albumTracks = get_album_tracks_only_from_artist(album, request)
+            #     artistTracks += albumTracks
+
+            # q = WorkerPool(poolSize=4)
+            # dlm = DownloadManager(q)
+            # w = q.do(get_album_tracks_only_from_artist, artistAlbums)
 
             downloader.download_multiple_songs(songObjList)
 

--- a/spotdl/__main__.py
+++ b/spotdl/__main__.py
@@ -3,7 +3,7 @@ from spotdl.search.spotifyClient import initialize
 from sys import argv as cliArgs
 
 #! Song Search from different start points
-from spotdl.search.utils import get_playlist_tracks, get_album_tracks, search_for_song, get_artist_albums
+from spotdl.search.utils import get_playlist_tracks, get_album_tracks, search_for_song, get_artist_tracks
 from spotdl.search.songObj import SongObj
 
 #! The actual download stuff
@@ -30,9 +30,9 @@ To download a playlist run,
     spotdl $playlistUrl
     eg. spotdl https://open.spotify.com/playlist/37i9dQZF1DWXhcuQw7KIeM?si=xubKHEBESM27RqGkqoXzgQ
 
-To download an artists songs run,
+To download an artist's songs run,
     spotdl $artistUrl
-    rg. spotdl https://open.spotify.com/artist/6fOMl44jA4Sp5b9PpYCkzz
+    eg. spotdl https://open.spotify.com/artist/6fOMl44jA4Sp5b9PpYCkzz
 
 To search for and download a song (not very accurate) run,
     spotdl $songQuery
@@ -104,14 +104,10 @@ def console_entry_point():
             downloader.download_multiple_songs(songObjList)
 
         elif ('open.spotify.com' in request and 'artist' in request) or 'spotify:artist:' in request:
-            print('Fetching Artist Albums...')
-            artistAlbums = get_artist_albums(request)
+            print('Fetching Artist\'s Tracks...')
+            songObjList = get_artist_tracks(request)
 
-            for album in artistAlbums.items():
-                print('Fetching songs from "%s"' % album[0])
-
-                songObjList = get_album_tracks(album[1])
-                downloader.download_multiple_songs(songObjList)
+            downloader.download_multiple_songs(songObjList)
 
         elif request.endswith('.txt'):
             print('Fetching songs from %s...' % request)

--- a/spotdl/__main__.py
+++ b/spotdl/__main__.py
@@ -3,7 +3,7 @@ from spotdl.search.spotifyClient import initialize
 from sys import argv as cliArgs
 
 #! Song Search from different start points
-from spotdl.search.utils import get_playlist_tracks, get_album_tracks, search_for_song
+from spotdl.search.utils import get_playlist_tracks, get_album_tracks, search_for_song, get_artist_albums
 from spotdl.search.songObj import SongObj
 
 #! The actual download stuff
@@ -29,6 +29,10 @@ To download a album run,
 To download a playlist run,
     spotdl $playlistUrl
     eg. spotdl https://open.spotify.com/playlist/37i9dQZF1DWXhcuQw7KIeM?si=xubKHEBESM27RqGkqoXzgQ
+
+To download an artists songs run,
+    spotdl $artistUrl
+    rg. spotdl https://open.spotify.com/artist/6fOMl44jA4Sp5b9PpYCkzz
 
 To search for and download a song (not very accurate) run,
     spotdl $songQuery
@@ -86,18 +90,28 @@ def console_entry_point():
                 print('Skipping %s (%s) as no match could be found on youtube' % (
                     song.get_song_name(), request
                 ))
-        
+
         elif ('open.spotify.com' in request and 'album' in request) or 'spotify:album:' in request:
             print('Fetching Album...')
             songObjList = get_album_tracks(request)
 
             downloader.download_multiple_songs(songObjList)
-        
+
         elif ('open.spotify.com' in request and 'playlist' in request) or 'spotify:playlist:' in request:
             print('Fetching Playlist...')
             songObjList = get_playlist_tracks(request)
 
             downloader.download_multiple_songs(songObjList)
+
+        elif ('open.spotify.com' in request and 'artist' in request) or 'spotify:artist:' in request:
+            print('Fetching Artist Albums...')
+            artistAlbums = get_artist_albums(request)
+
+            for album in artistAlbums.items():
+                print('Fetching songs from "%s"' % album[0])
+
+                songObjList = get_album_tracks(album[1])
+                downloader.download_multiple_songs(songObjList)
 
         elif request.endswith('.txt'):
             print('Fetching songs from %s...' % request)

--- a/spotdl/__main__.py
+++ b/spotdl/__main__.py
@@ -3,7 +3,7 @@ from spotdl.search.spotifyClient import initialize
 from sys import argv as cliArgs
 
 #! Song Search from different start points
-from spotdl.search.utils import get_playlist_tracks, get_album_tracks, search_for_song, get_artist_tracks, get_artist_albums, get_album_tracks_only_from_artist
+from spotdl.search.utils import get_playlist_tracks, get_album_tracks, search_for_song, get_artist_tracks
 from spotdl.search.songObj import SongObj
 
 #! The actual download stuff
@@ -106,20 +106,6 @@ def console_entry_point():
         elif ('open.spotify.com' in request and 'artist' in request) or 'spotify:artist:' in request:
             print('Fetching Artist\'s Tracks...')
             songObjList = get_artist_tracks(request)
-            
-            # artistAlbums = get_artist_albums(request)
-            # artistTracks = []
-
-
-
-            # for album in artistAlbums:
-            #     print('looking deeper into ', album)
-            #     albumTracks = get_album_tracks_only_from_artist(album, request)
-            #     artistTracks += albumTracks
-
-            # q = WorkerPool(poolSize=4)
-            # dlm = DownloadManager(q)
-            # w = q.do(get_album_tracks_only_from_artist, artistAlbums)
 
             downloader.download_multiple_songs(songObjList)
 

--- a/spotdl/common/workers.py
+++ b/spotdl/common/workers.py
@@ -1,0 +1,41 @@
+from multiprocess.pool import Pool
+
+from typing import Callable, Any
+
+class WorkerPool():
+    def __init__(self, poolSize: int = 4):
+        self.__workerPool = Pool(poolSize)
+
+    def do(self, function:Callable, *args: Any) -> Any:
+        maxArgLength = 0
+
+        for arg in args:
+            if isinstance(arg, list):
+                if maxArgLength != 0 and len(arg) != maxArgLength:
+                    raise Exception('variable imputs should be of the same length')
+
+                elif maxArgLength == 0:
+                    maxArgLength = len(arg)
+
+        preparedArgs = []    
+
+        for index in range(maxArgLength):
+            cArg = []
+
+            for arg in args:
+                if isinstance(arg, list):
+                    cArg.append(arg[index])
+                else:
+                    cArg.append(arg)
+
+            preparedArgs.append(tuple(cArg))
+
+        results = self.__workerPool.starmap(
+            func = function,
+            iterable = preparedArgs
+        )
+
+        return results
+    
+    def close(self):
+        self.__workerPool.close()

--- a/spotdl/search/songObj.py
+++ b/spotdl/search/songObj.py
@@ -15,7 +15,7 @@ class SongObj():
     #====================
     #=== Constructors ===
     #====================
-    def __init__(self, rawTrackMeta, rawAlbumMeta, rawArtistMeta, youtubeLink, lyrics):
+    def __init__(self, rawTrackMeta, rawAlbumMeta, rawArtistMeta, youtubeLink=None, lyrics=None):
         self. __rawTrackMeta = rawTrackMeta
         self.__rawAlbumMeta  = rawArtistMeta
         self.__rawArtistMeta = rawArtistMeta
@@ -28,7 +28,7 @@ class SongObj():
     #! Note, since the following are class methods, an instance of songObj is initialized
     #! and passed to them
     @classmethod
-    def from_url(cls, spotifyURL: str):
+    def from_url(cls, spotifyURL: str, preliminary: bool=False):
         # check if URL is a playlist, user, artist or album, if yes raise an Exception,
         # else procede
         if not (('open.spotify.com' in spotifyURL and 'track' in spotifyURL)
@@ -64,6 +64,13 @@ class SongObj():
 
         for artist in rawTrackMeta['artists']:
             contributingArtists.append(artist['name'])
+
+        if preliminary:
+            return  cls(
+                rawTrackMeta, rawAlbumMeta,
+                rawArtistMeta
+            )
+
 
         youtubeLink = SongObj.searchProvider(
             songName,
@@ -110,9 +117,6 @@ class SongObj():
     def get_youtube_link(self) -> str:
         return self.__youtubeLink
     
-    def get_spotify_link(self) -> str:
-        return 'http://open.spotify.com/track/' + self.__rawTrackMeta['id']
-
     def get_spotify_link(self) -> str:
         return 'http://open.spotify.com/track/' + self.__rawTrackMeta['id']
 
@@ -180,6 +184,14 @@ class SongObj():
         '''
 
         return self.__lyrics
+
+    #! 7. Display Name
+    def get_display_name(self) -> str:
+        ''''
+        returns songs's display name.
+        '''
+
+        return str(self.get_song_name()) + " - " + str( ", ".join(self.get_contributing_artists()) )
 
     #! Album Details:
 

--- a/spotdl/search/spotifyClient.py
+++ b/spotdl/search/spotifyClient.py
@@ -37,7 +37,8 @@ def initialize(clientId: str, clientSecret: str):
     global masterClient
 
     if masterClient:
-        raise Exception('A spotify client has already been initialized')
+        # raise Exception('A spotify client has already been initialized')
+        return
 
 
 

--- a/spotdl/search/utils.py
+++ b/spotdl/search/utils.py
@@ -110,6 +110,7 @@ def get_artist_tracks(artistUrl: str) -> List[SongObj]:
     artistTracks = []
 
     artistResponse = spotifyClient.artist_albums(artistUrl)
+    artistName     = spotifyClient.artist(artistUrl)['name']
 
     while True:
 
@@ -129,7 +130,10 @@ def get_artist_tracks(artistUrl: str) -> List[SongObj]:
 
     for album in artistAlbums:
         albumTracks = get_album_tracks(album)
-        
+
         artistTracks += albumTracks
+
+    #! Filter out the Songs in which the given artist has not contributed.
+    artistTracks = [track for track in artistTracks if artistName in track.get_contributing_artists()]
 
     return artistTracks

--- a/spotdl/search/utils.py
+++ b/spotdl/search/utils.py
@@ -102,7 +102,7 @@ def get_artist_tracks(artistUrl: str) -> List[SongObj]:
     `str` `artistUrl` : Spotify Url of the artist whose tracks are to be
     retrieved
 
-    returns a `dict` containing Url's of each track of the artist.
+    returns a `List` containing Url's of each track of the artist.
     '''
 
     spotifyClient = get_spotify_client()

--- a/spotdl/search/utils.py
+++ b/spotdl/search/utils.py
@@ -97,7 +97,7 @@ def get_playlist_tracks(playlistUrl: str) -> List[SongObj]:
     return playlistTracks
 
 
-def get_artist_tracks(artistUrl: str) -> List[SongObj]:
+def get_artist_tracks_old(artistUrl: str) -> List[SongObj]:
     '''
     `str` `artistUrl` : Spotify Url of the artist whose tracks are to be
     retrieved
@@ -137,3 +137,50 @@ def get_artist_tracks(artistUrl: str) -> List[SongObj]:
     artistTracks = [track for track in artistTracks if artistName in track.get_contributing_artists()]
 
     return artistTracks
+
+
+def get_artist_tracks(artistUrl: str) -> List[SongObj]:
+    '''
+    `str` `artistUrl` : Spotify Url of the artist whose tracks are to be
+    retrieved
+
+    returns a `List` containing Url's of each track of the artist.
+    '''
+
+    spotifyClient = get_spotify_client()
+
+    # artistResponse = spotifyClient.artist_albums(artistUrl)
+    artistName      = spotifyClient.artist(artistUrl)['name']
+    artistTracks     = []
+
+    artistResponse = spotifyClient.search(q='artist:' + artistName, type='track')
+
+    print(artistResponse)
+
+    # while loop acts like do-while
+    while True:
+
+        for track in artistResponse['tracks']['items']:
+            song = SongObj.from_url('https://open.spotify.com/track/' + track['id'])
+            print(song)
+
+            if (song.get_youtube_link() != None) and (artistName in song.get_contributing_artists()):
+                artistTracks.append(song)
+                print(song, song.get_song_name())
+
+        # check if more tracks are to be passed
+        if artistResponse['tracks']['next']:
+            artistResponse = spotifyClient.search(
+                q='artist:' + artistName, 
+                type='track',
+                offset = len(artistTracks)
+            )
+        else:
+            break
+
+    #! Filter out the Songs in which the given artist has not contributed.
+    # artistTracks = [track for track in artistTracks if artistName in track.get_contributing_artists()]
+
+    # print(artistTracks)
+
+    # return artistTracks

--- a/spotdl/search/utils.py
+++ b/spotdl/search/utils.py
@@ -1,7 +1,7 @@
 from spotdl.search.spotifyClient import get_spotify_client
 from spotdl.search.songObj import SongObj
 
-from typing import List
+from typing import Dict, List
 
 def search_for_song(query: str) ->  SongObj:
     '''
@@ -23,12 +23,12 @@ def search_for_song(query: str) ->  SongObj:
         for songResult in result['tracks']['items']:
             songUrl = 'http://open.spotify.com/track/' + songResult['id']
             song = SongObj.from_url(songUrl)
-            
+
             if song.get_youtube_link() != None:
                 return song
-        
+
         raise Exception('Could not match any of the results on YouTube')
-        
+
 def get_album_tracks(albumUrl: str) -> List[SongObj]:
     '''
     `str` `albumUrl` : Spotify Url of the album whose tracks are to be
@@ -47,10 +47,10 @@ def get_album_tracks(albumUrl: str) -> List[SongObj]:
 
         for track in trackResponse['items']:
             song = SongObj.from_url('https://open.spotify.com/track/' + track['id'])
-            
+
             if song.get_youtube_link() != None:
                 albumTracks.append(song)
-        
+
         # check if more tracks are to be passed
         if trackResponse['next']:
             trackResponse = spotifyClient.album_tracks(
@@ -59,7 +59,7 @@ def get_album_tracks(albumUrl: str) -> List[SongObj]:
             )
         else:
             break
-    
+
     return albumTracks
 
 def get_playlist_tracks(playlistUrl: str) -> List[SongObj]:
@@ -81,11 +81,11 @@ def get_playlist_tracks(playlistUrl: str) -> List[SongObj]:
         for songEntry in playlistResponse['items']:
             song = SongObj.from_url(
                 'https://open.spotify.com/track/' + songEntry['track']['id'])
-            
+
             if song.get_youtube_link() != None:
                 playlistTracks.append(song)
 
-        # check if more tracks are to be passed        
+        # check if more tracks are to be passed
         if playlistResponse['next']:
             playlistResponse = spotifyClient.playlist_tracks(
                 playlistUrl,
@@ -93,5 +93,27 @@ def get_playlist_tracks(playlistUrl: str) -> List[SongObj]:
             )
         else:
             break
-    
+
     return playlistTracks
+
+
+def get_artist_albums(artistUrl: str) -> Dict:
+    '''
+    `str` `artistUrl` : Spotify Url of the artist whose tracks are to be
+    retrieved
+
+    returns a `dict` containing Url's of each album of the artist. {'albumName':'albumUrl'}
+    '''
+
+    spotifyClient = get_spotify_client()
+    artistAlbums = {}
+
+    artistResponse = spotifyClient.artist_albums(artistUrl)
+
+    for album in artistResponse['items']:
+        albumName = album['name']
+        albumUrl  = album['external_urls']['spotify']
+
+        artistAlbums[albumName] = albumUrl
+
+    return artistAlbums

--- a/spotdl/search/utils.py
+++ b/spotdl/search/utils.py
@@ -97,23 +97,39 @@ def get_playlist_tracks(playlistUrl: str) -> List[SongObj]:
     return playlistTracks
 
 
-def get_artist_albums(artistUrl: str) -> Dict:
+def get_artist_tracks(artistUrl: str) -> List[SongObj]:
     '''
     `str` `artistUrl` : Spotify Url of the artist whose tracks are to be
     retrieved
 
-    returns a `dict` containing Url's of each album of the artist. {'albumName':'albumUrl'}
+    returns a `dict` containing Url's of each track of the artist.
     '''
 
     spotifyClient = get_spotify_client()
-    artistAlbums = {}
+    artistAlbums = []
+    artistTracks = []
 
     artistResponse = spotifyClient.artist_albums(artistUrl)
 
-    for album in artistResponse['items']:
-        albumName = album['name']
-        albumUrl  = album['external_urls']['spotify']
+    while True:
 
-        artistAlbums[albumName] = albumUrl
+        for album in artistResponse['items']:
+            albumUrl  = album['external_urls']['spotify']
 
-    return artistAlbums
+            artistAlbums.append(albumUrl)
+
+        # Check if the artist has more albums.
+        if artistResponse['next']:
+            artistResponse = spotifyClient.artist_albums(
+                artistUrl,
+                offset = len(artistAlbums)
+            )
+        else:
+            break
+
+    for album in artistAlbums:
+        albumTracks = get_album_tracks(album)
+        
+        artistTracks.append(albumTracks)
+
+    return artistTracks

--- a/spotdl/search/utils.py
+++ b/spotdl/search/utils.py
@@ -2,6 +2,7 @@ from spotdl.search.spotifyClient import get_spotify_client
 from spotdl.search.songObj import SongObj
 
 from typing import List
+import multiprocessing
 
 def search_for_song(query: str) ->  SongObj:
     '''
@@ -34,13 +35,14 @@ def get_album_tracks(albumUrl: str) -> List[SongObj]:
     `str` `albumUrl` : Spotify Url of the album whose tracks are to be
     retrieved
 
-    returns a `list<songObj>` containing Url's of each track in the given album
+    returns a `list<songObj>` containing URLs of each track in the given album
     '''
 
     spotifyClient = get_spotify_client()
     albumTracks = []
 
     trackResponse = spotifyClient.album_tracks(albumUrl)
+    print('looking deeper into ', album)
 
     # while loop acts like do-while
     while True:
@@ -61,6 +63,26 @@ def get_album_tracks(albumUrl: str) -> List[SongObj]:
             break
 
     return albumTracks
+
+def get_album_tracks_only_from_artist(albumUrl: str, artistUrl: str) -> List[SongObj]:
+    '''
+    `str` `albumUrl` : Spotify Url of the album whose tracks are to be
+    retrieved
+
+    `str` `albumUrl` : Spotify Url of the artist to filter
+
+    returns a `list<songObj>` containing URLs of each track in the given album that are contributed to byt the given artist
+    '''
+
+    spotifyClient   = get_spotify_client()
+
+    artistName      = spotifyClient.artist(artistUrl)['name']
+
+    albumTracks     = get_album_tracks(albumUrl)
+
+    albumTracksByArtist     = [track for track in albumTracks if artistName in track.get_contributing_artists()]
+
+    return albumTracksByArtist
 
 def get_playlist_tracks(playlistUrl: str) -> List[SongObj]:
     '''
@@ -115,25 +137,76 @@ def get_artist_tracks(artistUrl: str) -> List[SongObj]:
     while True:
 
         for album in artistResponse['items']:
+            print('looking into ', album)
             albumUrl  = album['external_urls']['spotify']
 
             artistAlbums.append(albumUrl)
 
         # Check if the artist has more albums.
         if artistResponse['next']:
+            print('I have more...')
             artistResponse = spotifyClient.artist_albums(
                 artistUrl,
                 offset = len(artistAlbums)
             )
         else:
+            print('got it all')
             break
 
-    for album in artistAlbums:
-        albumTracks = get_album_tracks(album)
+    # for album in artistAlbums:
+    #     print('looking deeper into ', album)
+    #     albumTracks = get_album_tracks(album)
 
-        artistTracks += albumTracks
+    #     artistTracks += albumTracks
+
+    pool_size = multiprocessing.cpu_count() * 2
+    pool = multiprocessing.Pool(processes=pool_size,
+                                # initializer=start_process,
+                                # maxtasksperchild=2,
+                                )
+    
+    artistTracks = pool.map(get_album_tracks, artistAlbums)
 
     #! Filter out the Songs in which the given artist has not contributed.
     artistTracks = [track for track in artistTracks if artistName in track.get_contributing_artists()]
 
+    print('returning')
+
     return artistTracks
+
+
+def get_artist_albums(artistUrl: str) -> List[SongObj]:
+    '''
+    `str` `artistUrl` : Spotify Url of the artist whose tracks are to be
+    retrieved
+
+    returns a `List` containing Url's of each track of the artist.
+    '''
+
+    spotifyClient = get_spotify_client()
+    artistAlbums = []
+    # artistTracks = []
+
+    artistResponse = spotifyClient.artist_albums(artistUrl)
+    # artistName     = spotifyClient.artist(artistUrl)['name']
+
+    while True:
+
+        for album in artistResponse['items']:
+            print('looking into ', album)
+            albumUrl  = album['external_urls']['spotify']
+
+            artistAlbums.append(albumUrl)
+
+        # Check if the artist has more albums.
+        if artistResponse['next']:
+            print('I have more...')
+            artistResponse = spotifyClient.artist_albums(
+                artistUrl,
+                offset = len(artistAlbums)
+            )
+        else:
+            print('got it all')
+            break
+
+    return artistAlbums

--- a/spotdl/search/utils.py
+++ b/spotdl/search/utils.py
@@ -1,7 +1,7 @@
 from spotdl.search.spotifyClient import get_spotify_client
 from spotdl.search.songObj import SongObj
 
-from typing import Dict, List
+from typing import List
 
 def search_for_song(query: str) ->  SongObj:
     '''
@@ -130,6 +130,6 @@ def get_artist_tracks(artistUrl: str) -> List[SongObj]:
     for album in artistAlbums:
         albumTracks = get_album_tracks(album)
         
-        artistTracks.append(albumTracks)
+        artistTracks += albumTracks
 
     return artistTracks

--- a/spotdl/search/utils.py
+++ b/spotdl/search/utils.py
@@ -7,19 +7,19 @@ from typing import List
 
 
 def _get_songObj_from_url(url):
-    initialize(
-        clientId     = '4fe3fecfe5334023a1472516cc99d805',
-        clientSecret = '0f02b7c483c04257984695007a4a8d5c'
-    )
+    # initialize(
+    #     clientId     = '4fe3fecfe5334023a1472516cc99d805',
+    #     clientSecret = '0f02b7c483c04257984695007a4a8d5c'
+    # )
     song = SongObj.from_url(url)
     if song.get_youtube_link() != None:
         return song
 
 def _get_songObj_from_url_and_artist(url, artistName):
-    initialize(
-        clientId     = '4fe3fecfe5334023a1472516cc99d805',
-        clientSecret = '0f02b7c483c04257984695007a4a8d5c'
-    )
+    # initialize(
+    #     clientId     = '4fe3fecfe5334023a1472516cc99d805',
+    #     clientSecret = '0f02b7c483c04257984695007a4a8d5c'
+    # )
     song_preliminary = SongObj.from_url(url, preliminary=True)
     if artistName in song_preliminary.get_contributing_artists():
         song = SongObj.from_url(url, preliminary=False)
@@ -169,6 +169,8 @@ def get_artist_tracks(artistUrl: str, isPrimaryArtist: bool=False) -> List[SongO
     `str` `artistUrl` : Spotify URL of the artist whose tracks are to be
     retrieved
 
+    `bool` `isPrimaryArtist` : Whether or not to search for songs that include him as contributing artist
+
     returns a `List` containing URLs of each track in which the specified 
     artist is the primary/contributing artist.
     '''
@@ -179,9 +181,9 @@ def get_artist_tracks(artistUrl: str, isPrimaryArtist: bool=False) -> List[SongO
     songURLlist = []
 
     if isPrimaryArtist == True:
-        searchQuery = q='artist:' + artistName
+        searchQuery = q='artist:' + artistName  # Spotify API for searching for songs where he is the primary artist
     else:
-        searchQuery = q=artistName
+        searchQuery = q=artistName # Generic search for songs
 
     artistResponse = spotifyClient.search(q= searchQuery, type='track')
 
@@ -233,11 +235,10 @@ def get_artist_discography(artistUrl: str) -> List[SongObj]:
     artistAlbums = []
     artistTracks = []
 
-    artistResponse = spotifyClient.artist_albums(artistUrl, album_type='album,single')
+    artistResponse = spotifyClient.artist_albums(artistUrl, album_type='album,single') # ‘album’, ‘single’, ‘appears_on’, ‘compilation’, 'None': all
     artistName     = spotifyClient.artist(artistUrl)['name']
 
-    # songURLlist = []
-
+    # Gather albums
     while True:
 
         for album in artistResponse['items']:
@@ -257,6 +258,7 @@ def get_artist_discography(artistUrl: str) -> List[SongObj]:
 
     print('Found', len(artistAlbums), 'albums')
 
+    # Gather tracks from those albums.
     for album in artistAlbums:
 
         trackResponse = spotifyClient.album_tracks(album)


### PR DESCRIPTION
Speed up gathering large quantities of spotdl Objects. Specifically for gathering artist tracks. Implementation was created in #935 and the issue was also addressed in #935

- Use multiprocessing when `SongObj.from_url()`
  - Also add flag `preliminary: bool` to `SongObj.from_url()` for quick Spotify-only metadata gathering
- Serialize `masterClient` into file for access outside main process.
- Allow calling `initialize()` multiple times from different "processes" by serializing instance into file.

Results are approximately +4x faster. 
*Although there is still a blank wait for large collections, in the future this can utilize `progressHandler` to show messages and progress bars for collection status.*