### PR TITLE
Fix #995

### DIFF
--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -218,7 +218,10 @@ class DownloadManager():
         command = 'ffmpeg -v quiet -y -i "%s" -acodec libmp3lame -abr true ' \
                  f'-b:a {trackAudioStream.bitrate} ' \
                   '-af "apad=pad_dur=2, dynaudnorm, loudnorm=I=-17" "%s"'
-        formattedCommand = command % (downloadedFilePath, convertedFilePath)
+        formattedCommand = command % (
+            downloadedFilePath.replace('$', '\$'),
+            convertedFilePath.replace('$', '\$')
+        )
 
         process = await asyncio.subprocess.create_subprocess_shell(formattedCommand)
         _ = await process.communicate()

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -210,6 +210,7 @@ class DownloadManager():
         # ! as 47 seconds long in your music player, yeah that was an issue earlier.)
 
         command = 'ffmpeg -v quiet -y -i "%s" -acodec libmp3lame -abr true ' \
+                 f'-b:a {trackAudioStream.bitrate} ' \
                   '-af "apad=pad_dur=2, dynaudnorm, loudnorm=I=-17" "%s"'
         formattedCommand = command % (downloadedFilePath, convertedFilePath)
 

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -180,7 +180,13 @@ class DownloadManager():
         else:
             youtubeHandler = YouTube(songObj.get_youtube_link())
 
-        trackAudioStream = youtubeHandler.streams.get_audio_only()
+        trackAudioStream = youtubeHandler.streams.filter(only_audio=True).order_by('bitrate').last()
+
+        if not trackAudioStream:
+            print(f"Unable to get audio stream for \"{songObj.get_song_name()}\" "
+                  f"by \"{songObj.get_contributing_artists()[0]}\" "
+                  f"from video \"{songObj.get_youtube_link()}\"")
+            return None
 
         downloadedFilePath = await self._download_from_youtube(convertedFileName, tempFolder,
                                                                trackAudioStream)


### PR DESCRIPTION
Pass the appropriate bitrate to ffmpeg so that files aren't all 64kpbs anymore. I am not actually sure whether this changes quality in any way because the resulting file size hardly changed at all. At the very least it sets the appropriate metadata.

Also the audio stream selection now chooses the stream with highest bitrate. Before it was limited to only mp4 streams. 