### PR TITLE
Improved Temp File Handling

### DIFF
--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -132,7 +132,7 @@ class DownloadManager():
         tempFolder = Path('.', 'Temp')
 
         if not tempFolder.exists():
-            Path.mkdir(tempFolder)
+            tempFolder.mkdir()
 
         # build file name of converted file
         artistStr = ''
@@ -158,7 +158,7 @@ class DownloadManager():
         convertedFileName = convertedFileName.replace(
             '"', "'").replace(': ', ' - ')
 
-        convertedFilePath = Path('.', convertedFileName + '.mp3')
+        convertedFilePath = Path(".", f"{convertedFileName}.mp3")
 
         # if a song is already downloaded skip it
         if convertedFilePath.is_file():
@@ -191,10 +191,10 @@ class DownloadManager():
         downloadedFilePathString = await self._download_from_youtube(convertedFileName, tempFolder,
                                                                      trackAudioStream)
 
-        downloadedFilePath = Path(downloadedFilePathString)
-
-        if downloadedFilePath is None:
+        if downloadedFilePathString is None:
             return None
+
+        downloadedFilePath = Path(downloadedFilePathString)
 
         # convert downloaded file to MP3 with normalization
 
@@ -312,7 +312,8 @@ class DownloadManager():
             self.downloadTracker.notify_download_completion(songObj)
 
         # delete the unnecessary YouTube download File
-        downloadedFilePath.unlink()
+        if downloadedFilePath and downloadedFilePath.is_file():
+            downloadedFilePath.unlink()
 
     def close(self) -> None:
         '''
@@ -338,7 +339,7 @@ class DownloadManager():
     def _perform_audio_download(self, convertedFileName, tempFolder, trackAudioStream):
         # ! The actual download, if there is any error, it'll be here,
         try:
-            # ! pyTube will save the song in .\Temp\$songName.mp4, it doesn't save as '.mp3'
+            # ! pyTube will save the song in .\Temp\$songName.mp4 or .webm, it doesn't save as '.mp3'
             downloadedFilePath = trackAudioStream.download(
                 output_path=tempFolder,
                 filename=convertedFileName,
@@ -350,9 +351,10 @@ class DownloadManager():
             # ! downloadTrackers download queue and all is well...
             # !
             # ! None is again used as a convenient exit
-            tempFile = Path(tempFolder).glob(convertedFileName + '.*')
-            if tempFile.is_file():
-                tempFile.unlink()
+            tempFiles = Path(tempFolder).glob(convertedFileName + '.*')
+            for tempFile in tempFiles:
+                if tempFile.is_file():
+                    tempFile.unlink()
             return None
 
     async def _pool_download(self, song_obj: SongObj):

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -221,10 +221,21 @@ class DownloadManager():
         command = 'ffmpeg -v quiet -y -i "%s" -acodec libmp3lame -abr true ' \
             f'-b:a {trackAudioStream.bitrate} ' \
                   '-af "apad=pad_dur=2, dynaudnorm, loudnorm=I=-17" "%s"'
-        formattedCommand = command % (
-            str(downloadedFilePath).replace('$', '\$'),
-            str(convertedFilePath).replace('$', '\$')
-        )
+
+        # ! bash/ffmpeg on Unix systems need to have excape char (\) for special characters: \$
+        # ! alternatively the quotes could be reversed (single <-> double) in the command then
+        # ! the windows special characters needs escaping (^): ^\  ^&  ^|  ^>  ^<  ^^
+
+        if sys.platform == 'win32':
+            formattedCommand = command % (
+                str(downloadedFilePath),
+                str(convertedFilePath)
+            )
+        else:
+            formattedCommand = command % (
+                str(downloadedFilePath).replace('$', '\$'),
+                str(convertedFilePath).replace('$', '\$')
+            )
 
         process = await asyncio.subprocess.create_subprocess_shell(formattedCommand)
         _ = await process.communicate()

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -113,20 +113,16 @@ class DownloadManager():
         '''
         `songObj` `songObj` : song to be downloaded
 
-        `AutoProxy` `displayManager` : autoproxy reference to a `DisplayManager`
-
-        `AutoProxy` `downloadTracker`: autoproxy reference to a `DownloadTracker`
-
         RETURNS `~`
 
         Downloads, Converts, Normalizes song & embeds metadata as ID3 tags.
         '''
 
-        # ! all YouTube downloads are to .\Temp; they are then converted and put into .\ and
-        # ! finally followed up with ID3 metadata tags
+        #! all YouTube downloads are to .\Temp; they are then converted and put into .\ and
+        #! finally followed up with ID3 metadata tags
 
-        # ! we explicitly use the os.path.join function here to ensure download is
-        # ! platform agnostic
+        #! we explicitly use the os.path.join function here to ensure download is
+        #! platform agnostic
 
         # Create a .\Temp folder if not present
         tempFolder = Path('.', 'Temp')
@@ -137,24 +133,24 @@ class DownloadManager():
         # build file name of converted file
         artistStr = ''
 
-        # ! we eliminate contributing artist names that are also in the song name, else we
-        # ! would end up with things like 'Jetta, Mastubs - I'd love to change the world
-        # ! (Mastubs REMIX).mp3' which is kinda an odd file name.
+        #! we eliminate contributing artist names that are also in the song name, else we
+        #! would end up with things like 'Jetta, Mastubs - I'd love to change the world
+        #! (Mastubs REMIX).mp3' which is kinda an odd file name.
         for artist in songObj.get_contributing_artists():
             if artist.lower() not in songObj.get_song_name().lower():
                 artistStr += artist + ', '
 
-        # ! the ...[:-2] is to avoid the last ', ' appended to artistStr
+        #! the ...[:-2] is to avoid the last ', ' appended to artistStr
         convertedFileName = artistStr[:-2] + ' - ' + songObj.get_song_name()
 
-        # ! this is windows specific (disallowed chars)
+        #! this is windows specific (disallowed chars)
         for disallowedChar in ['/', '?', '\\', '*', '|', '<', '>']:
             if disallowedChar in convertedFileName:
                 convertedFileName = convertedFileName.replace(
                     disallowedChar, '')
 
-        # ! double quotes (") and semi-colons (:) are also disallowed characters but we would
-        # ! like to retain their equivalents, so they aren't removed in the prior loop
+        #! double quotes (") and semi-colons (:) are also disallowed characters but we would
+        #! like to retain their equivalents, so they aren't removed in the prior loop
         convertedFileName = convertedFileName.replace(
             '"', "'").replace(': ', ' - ')
 
@@ -167,8 +163,8 @@ class DownloadManager():
             if self.downloadTracker:
                 self.downloadTracker.notify_download_completion(songObj)
 
-            # ! None is the default return value of all functions, we just explicitly define
-            # ! it here as a continent way to avoid executing the rest of the function.
+            #! None is the default return value of all functions, we just explicitly define
+            #! it here as a continent way to avoid executing the rest of the function.
             return None
 
         # download Audio from YouTube
@@ -198,33 +194,33 @@ class DownloadManager():
 
         # convert downloaded file to MP3 with normalization
 
-        # ! -af loudnorm=I=-7:LRA applies EBR 128 loudness normalization algorithm with
-        # ! intergrated loudness target (I) set to -17, using values lower than -15
-        # ! causes 'pumping' i.e. rhythmic variation in loudness that should not
-        # ! exist -loud parts exaggerate, soft parts left alone.
-        # !
-        # ! dynaudnorm applies dynamic non-linear RMS based normalization, this is what
-        # ! actually normalized the audio. The loudnorm filter just makes the apparent
-        # ! loudness constant
-        # !
-        # ! apad=pad_dur=2 adds 2 seconds of silence toward the end of the track, this is
-        # ! done because the loudnorm filter clips/cuts/deletes the last 1-2 seconds on
-        # ! occasion especially if the song is EDM-like, so we add a few extra seconds to
-        # ! combat that.
-        # !
-        # ! -acodec libmp3lame sets the encoded to 'libmp3lame' which is far better
-        # ! than the default 'mp3_mf', '-abr true' automatically determines and passes the
-        # ! audio encoding bitrate to the filters and encoder. This ensures that the
-        # ! sampled length of songs matches the actual length (i.e. a 5 min song won't display
-        # ! as 47 seconds long in your music player, yeah that was an issue earlier.)
+        #! -af loudnorm=I=-7:LRA applies EBR 128 loudness normalization algorithm with
+        #! intergrated loudness target (I) set to -17, using values lower than -15
+        #! causes 'pumping' i.e. rhythmic variation in loudness that should not
+        #! exist -loud parts exaggerate, soft parts left alone.
+        #!
+        #! dynaudnorm applies dynamic non-linear RMS based normalization, this is what
+        #! actually normalized the audio. The loudnorm filter just makes the apparent
+        #! loudness constant
+        #!
+        #! apad=pad_dur=2 adds 2 seconds of silence toward the end of the track, this is
+        #! done because the loudnorm filter clips/cuts/deletes the last 1-2 seconds on
+        #! occasion especially if the song is EDM-like, so we add a few extra seconds to
+        #! combat that.
+        #!
+        #! -acodec libmp3lame sets the encoded to 'libmp3lame' which is far better
+        #! than the default 'mp3_mf', '-abr true' automatically determines and passes the
+        #! audio encoding bitrate to the filters and encoder. This ensures that the
+        #! sampled length of songs matches the actual length (i.e. a 5 min song won't display
+        #! as 47 seconds long in your music player, yeah that was an issue earlier.)
 
         command = 'ffmpeg -v quiet -y -i "%s" -acodec libmp3lame -abr true ' \
             f'-b:a {trackAudioStream.bitrate} ' \
                   '-af "apad=pad_dur=2, dynaudnorm, loudnorm=I=-17" "%s"'
 
-        # ! bash/ffmpeg on Unix systems need to have excape char (\) for special characters: \$
-        # ! alternatively the quotes could be reversed (single <-> double) in the command then
-        # ! the windows special characters needs escaping (^): ^\  ^&  ^|  ^>  ^<  ^^
+        #! bash/ffmpeg on Unix systems need to have excape char (\) for special characters: \$
+        #! alternatively the quotes could be reversed (single <-> double) in the command then
+        #! the windows special characters needs escaping (^): ^\  ^&  ^|  ^>  ^<  ^^
 
         if sys.platform == 'win32':
             formattedCommand = command % (
@@ -240,7 +236,7 @@ class DownloadManager():
         process = await asyncio.subprocess.create_subprocess_shell(formattedCommand)
         _ = await process.communicate()
 
-        # ! Wait till converted file is actually created
+        #! Wait till converted file is actually created
         while True:
             if convertedFilePath.is_file():
                 break
@@ -249,47 +245,47 @@ class DownloadManager():
             self.displayManager.notify_conversion_completion()
 
         # embed song details
-        # ! we save tags as both ID3 v2.3 and v2.4
+        #! we save tags as both ID3 v2.3 and v2.4
 
-        # ! The simple ID3 tags
+        #! The simple ID3 tags
         audioFile = EasyID3(convertedFilePath)
 
-        # ! Get rid of all existing ID3 tags (if any exist)
+        #! Get rid of all existing ID3 tags (if any exist)
         audioFile.delete()
 
-        # ! song name
+        #! song name
         audioFile['title'] = songObj.get_song_name()
         audioFile['titlesort'] = songObj.get_song_name()
 
-        # ! track number
+        #! track number
         audioFile['tracknumber'] = str(songObj.get_track_number())
 
-        # ! genres (pretty pointless if you ask me)
-        # ! we only apply the first available genre as ID3 v2.3 doesn't support multiple
-        # ! genres and ~80% of the world PC's run Windows - an OS with no ID3 v2.4 support
+        #! genres (pretty pointless if you ask me)
+        #! we only apply the first available genre as ID3 v2.3 doesn't support multiple
+        #! genres and ~80% of the world PC's run Windows - an OS with no ID3 v2.4 support
         genres = songObj.get_genres()
 
         if len(genres) > 0:
             audioFile['genre'] = genres[0]
 
-        # ! all involved artists
+        #! all involved artists
         audioFile['artist'] = songObj.get_contributing_artists()
 
-        # ! album name
+        #! album name
         audioFile['album'] = songObj.get_album_name()
 
-        # ! album artist (all of 'em)
+        #! album artist (all of 'em)
         audioFile['albumartist'] = songObj.get_album_artists()
 
-        # ! album release date (to what ever precision available)
+        #! album release date (to what ever precision available)
         audioFile['date'] = songObj.get_album_release()
         audioFile['originaldate'] = songObj.get_album_release()
 
-        # ! save as both ID3 v2.3 & v2.4 as v2.3 isn't fully features and
-        # ! windows doesn't support v2.4 until later versions of Win10
+        #! save as both ID3 v2.3 & v2.4 as v2.3 isn't fully features and
+        #! windows doesn't support v2.4 until later versions of Win10
         audioFile.save(v2_version=3)
 
-        # ! setting the album art
+        #! setting the album art
         audioFile = ID3(convertedFilePath)
 
         rawAlbumArt = urlopen(songObj.get_album_cover_url()).read()
@@ -324,10 +320,10 @@ class DownloadManager():
         self.displayManager.close()
 
     async def _download_from_youtube(self, convertedFileName, tempFolder, trackAudioStream):
-        # ! The following function calls blocking code, which would block whole event loop.
-        # ! Therefore it has to be called in a separate thread via ThreadPoolExecutor. This
-        # ! is not a problem, since GIL is released for the I/O operations, so it shouldn't
-        # ! hurt performance.
+        #! The following function calls blocking code, which would block whole event loop.
+        #! Therefore it has to be called in a separate thread via ThreadPoolExecutor. This
+        #! is not a problem, since GIL is released for the I/O operations, so it shouldn't
+        #! hurt performance.
         return await self.loop.run_in_executor(
             self.thread_executor,
             self._perform_audio_download,
@@ -337,9 +333,9 @@ class DownloadManager():
         )
 
     def _perform_audio_download(self, convertedFileName, tempFolder, trackAudioStream):
-        # ! The actual download, if there is any error, it'll be here,
+        #! The actual download, if there is any error, it'll be here,
         try:
-            # ! pyTube will save the song in .\Temp\$songName.mp4 or .webm, it doesn't save as '.mp3'
+            #! pyTube will save the song in .\Temp\$songName.mp4 or .webm, it doesn't save as '.mp3'
             downloadedFilePath = trackAudioStream.download(
                 output_path=tempFolder,
                 filename=convertedFileName,
@@ -347,18 +343,18 @@ class DownloadManager():
             )
             return downloadedFilePath
         except:
-            # ! This is equivalent to a failed download, we do nothing, the song remains on
-            # ! downloadTrackers download queue and all is well...
-            # !
-            # ! None is again used as a convenient exit
+            #! This is equivalent to a failed download, we do nothing, the song remains on
+            #! downloadTrackers download queue and all is well...
+            #!
+            #! None is again used as a convenient exit
             tempFiles = Path(tempFolder).glob(f'{convertedFileName}.*')
             for tempFile in tempFiles:
                 tempFile.unlink()
             return None
 
     async def _pool_download(self, song_obj: SongObj):
-        # ! Run asynchronous task in a pool to make sure that all processes
-        # ! don't run at once.
+        #! Run asynchronous task in a pool to make sure that all processes
+        #! don't run at once.
 
         # tasks that cannot acquire semaphore will wait here until it's free
         # only certain amount of tasks can acquire the semaphore at the same time

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -351,7 +351,7 @@ class DownloadManager():
             # ! downloadTrackers download queue and all is well...
             # !
             # ! None is again used as a convenient exit
-            tempFiles = Path(tempFolder).glob(convertedFileName + '.*')
+            tempFiles = Path(tempFolder).glob(f'{convertedFileName}.*')
             for tempFile in tempFiles:
                 tempFile.unlink()
             return None

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -353,8 +353,7 @@ class DownloadManager():
             # ! None is again used as a convenient exit
             tempFiles = Path(tempFolder).glob(convertedFileName + '.*')
             for tempFile in tempFiles:
-                if tempFile.is_file():
-                    tempFile.unlink()
+                tempFile.unlink()
             return None
 
     async def _pool_download(self, song_obj: SongObj):


### PR DESCRIPTION
This aligns with #1076 and is mentioned in #1103 
This should resolve: #1104 & #1103 

### Summary:
- Continuation of transition from os to pathlib for file handling done by @aklajnert 
  - #1076
- Removes any filetype from the `./Temp` directory after noticing `.webm` files were being leftover
  -  Potentially resulted from #1065 where it was improved to automatically selected the highest quality option (which possibly isn't always .mp4)
  - Mentioned in #1103
- Uses escape characters (\\) to avoid unintentional variable declarations in FFmpeg **only in non-windows systems**
  - Resolves #1103 and #1104
  - $ (dollar signs) causes code to hang.
  - Note: The temp file will be missing the `$` but that is an issue with pytube and it does not affect the final mp3 file name

### Resources
Windows Special Chars: https://ss64.com/nt/syntax-esc.html
Linux Special Chars: https://tldp.org/LDP/Bash-Beginners-Guide/html/sect_03_03.html#:~:text=Escape%20characters%20are%20used%20to,with%20the%20exception%20of%20newline.