### PR TITLE
Fix issue with search result duration greater than 24 hours.

### DIFF
--- a/spotdl/__init__.py
+++ b/spotdl/__init__.py
@@ -1,4 +1,5 @@
 __all__ = [
+    'console_entry_point',
     'search',
     'download',
 ]

--- a/spotdl/search/provider.py
+++ b/spotdl/search/provider.py
@@ -84,7 +84,7 @@ def __parse_duration(duration: str) -> float:
         return float(seconds)
 
     # ! This usually occurs when the wrong string is mistaken for the duration
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, AttributeError):
         return 0.0
 
 

--- a/spotdl/search/provider.py
+++ b/spotdl/search/provider.py
@@ -4,12 +4,6 @@
 
 # ! the following are for the search provider to function
 import typing
-<<<<<<< HEAD
-
-=======
-from datetime import timedelta
-from time import strptime
->>>>>>> fb2eddab9d922f136f7f832bc361c5740aaf4e1e
 # ! Just for static typing
 from typing import List
 
@@ -100,7 +94,7 @@ def _map_result_to_song_data(result: dict) -> dict:
         'name': result['title'],
         'type': result['resultType'],
         'artist': artists,
-        'length': __parse_duration(result.get('duration', None)),
+        'length': _parse_duration(result.get('duration', None)),
         'link': f'https://www.youtube.com/watch?v={video_id}',
         'position': 0
     }
@@ -127,7 +121,7 @@ def _query_and_simplify(searchTerm: str) -> List[dict]:
     print(f'Searching for: {searchTerm}')
     searchResult = ytmApiClient.search(searchTerm, filter='videos')
 
-    return list(map(__map_result_to_song_data, searchResult))
+    return list(map(_map_result_to_song_data, searchResult))
 
 
 # =======================
@@ -152,7 +146,7 @@ def search_and_order_ytm_results(songName: str, songArtists: List[str],
     that $matchValue can take is 100, the least value is unbound.
     '''
     # Query YTM
-    results = __query_and_simplify(get_ytm_search_query(songName, songArtists))
+    results = _query_and_simplify(get_ytm_search_query(songName, songArtists))
 
     # Assign an overall avg match value to each result
     linksWithMatchValue = {}

--- a/spotdl/search/provider.py
+++ b/spotdl/search/provider.py
@@ -4,7 +4,12 @@
 
 # ! the following are for the search provider to function
 import typing
+<<<<<<< HEAD
 
+=======
+from datetime import timedelta
+from time import strptime
+>>>>>>> fb2eddab9d922f136f7f832bc361c5740aaf4e1e
 # ! Just for static typing
 from typing import List
 

--- a/spotdl/search/provider.py
+++ b/spotdl/search/provider.py
@@ -71,7 +71,7 @@ def match_percentage(str1: str, str2: str, score_cutoff: float = 0) -> float:
 ytmApiClient = YTMusic()
 
 
-def __parse_duration(duration: str) -> float:
+def _parse_duration(duration: str) -> float:
     '''
     Convert string value of time (duration: "25:36:59") to a float value of seconds (92219.0)
     '''
@@ -88,7 +88,7 @@ def __parse_duration(duration: str) -> float:
         return 0.0
 
 
-def __map_result_to_song_data(result: dict) -> dict:
+def _map_result_to_song_data(result: dict) -> dict:
     artists = ", ".join(map(lambda a: a['name'], result['artists']))
     video_id = result['videoId']
     song_data = {
@@ -105,7 +105,7 @@ def __map_result_to_song_data(result: dict) -> dict:
     return song_data
 
 
-def __query_and_simplify(searchTerm: str) -> List[dict]:
+def _query_and_simplify(searchTerm: str) -> List[dict]:
     '''
     `str` `searchTerm` : the search term you would type into YTM's search bar
 

--- a/spotdl/search/provider.py
+++ b/spotdl/search/provider.py
@@ -79,8 +79,8 @@ def __parse_duration(duration: str) -> float:
         # {(1, "s"), (60, "m"), (3600, "h")}
         mappedIncrements = zip([1, 60, 3600], reversed(duration.split(":")))
         seconds = 0
-        for multiple, time in mappedIncrements:
-            seconds += multiple * int(time)
+        for multiplier, time in mappedIncrements:
+            seconds += multiplier * int(time)
         return float(seconds)
 
     # ! This usually occurs when the wrong string is mistaken for the duration

--- a/spotdl/search/provider.py
+++ b/spotdl/search/provider.py
@@ -4,8 +4,7 @@
 
 # ! the following are for the search provider to function
 import typing
-from datetime import timedelta
-from time import strptime
+
 # ! Just for static typing
 from typing import List
 
@@ -73,17 +72,18 @@ ytmApiClient = YTMusic()
 
 
 def __parse_duration(duration: str) -> float:
+    '''
+    Convert string value of time (duration: 25:36:59) to a float value of seconds (92219.0)
+    '''
     try:
-        if len(duration) > 5:
-            padded = duration.rjust(8, '0')
-            x = strptime(padded, '%H:%M:%S')
-        elif len(duration) > 2:
-            padded = duration.rjust(5, '0')
-            x = strptime(padded, '%M:%S')
-        else:
-            x = strptime(duration, '%S')
+        # {(3600, "h"), (60, "m"), (1, "s")}
+        mapped = zip([3600, 60, 1], duration.split(":"))
+        seconds = 0
+        for x, t in mapped:
+            seconds += x * int(t)
+        return float(seconds)
 
-        return timedelta(hours=x.tm_hour, minutes=x.tm_min, seconds=x.tm_sec).total_seconds()
+    # ! This usually occurs when the wrong string is mistaken for the duration
     except (ValueError, TypeError):
         return 0.0
 

--- a/spotdl/search/provider.py
+++ b/spotdl/search/provider.py
@@ -73,14 +73,14 @@ ytmApiClient = YTMusic()
 
 def __parse_duration(duration: str) -> float:
     '''
-    Convert string value of time (duration: 25:36:59) to a float value of seconds (92219.0)
+    Convert string value of time (duration: "25:36:59") to a float value of seconds (92219.0)
     '''
     try:
-        # {(3600, "h"), (60, "m"), (1, "s")}
-        mapped = zip([3600, 60, 1], duration.split(":"))
+        # {(1, "s"), (60, "m"), (3600, "h")}
+        mappedIncrements = zip([1, 60, 3600], reversed(duration.split(":")))
         seconds = 0
-        for x, t in mapped:
-            seconds += x * int(t)
+        for multiple, time in mappedIncrements:
+            seconds += multiple * int(time)
         return float(seconds)
 
     # ! This usually occurs when the wrong string is mistaken for the duration

--- a/spotdl/search/utils.py
+++ b/spotdl/search/utils.py
@@ -82,6 +82,9 @@ def get_playlist_tracks(playlistUrl: str) -> List[SongObj]:
     while True:
 
         for songEntry in playlistResponse['items']:
+            if songEntry['track'] is None or songEntry['track']['id'] is None:
+                continue
+
             song = SongObj.from_url(
                 'https://open.spotify.com/track/' + songEntry['track']['id'])
 
@@ -92,7 +95,11 @@ def get_playlist_tracks(playlistUrl: str) -> List[SongObj]:
         if playlistResponse['next']:
             playlistResponse = spotifyClient.playlist_tracks(
                 playlistUrl,
+<<<<<<< HEAD
                 offset=len(playlistTracks)
+=======
+                offset=playlistResponse['offset'] + playlistResponse['limit']
+>>>>>>> fb2eddab9d922f136f7f832bc361c5740aaf4e1e
             )
         else:
             break

--- a/spotdl/search/utils.py
+++ b/spotdl/search/utils.py
@@ -95,11 +95,7 @@ def get_playlist_tracks(playlistUrl: str) -> List[SongObj]:
         if playlistResponse['next']:
             playlistResponse = spotifyClient.playlist_tracks(
                 playlistUrl,
-<<<<<<< HEAD
-                offset=len(playlistTracks)
-=======
                 offset=playlistResponse['offset'] + playlistResponse['limit']
->>>>>>> fb2eddab9d922f136f7f832bc361c5740aaf4e1e
             )
         else:
             break

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,0 +1,14 @@
+from spotdl.search.provider import __parse_duration
+
+def test_parse_duration():
+    """
+    Test the duration parsing
+    """
+
+    assert __parse_duration("20") == float(20.0)
+    assert __parse_duration("25:59:59") == float(93599.0)
+    assert __parse_duration("25:59") == float(1559.0)
+    assert __parse_duration("likes") == float(0.0)
+    assert __parse_duration("views") == float(0.0)
+    assert __parse_duration([1, 2, 3]) == float(0.0)
+    assert __parse_duration({"json": "data"}) == float(0.0)

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,15 +1,15 @@
-from spotdl.search.provider import __parse_duration
+from spotdl.search.provider import _parse_duration
 
 def test_parse_duration():
     """
     Test the duration parsing
     """
 
-    assert __parse_duration("3:16") == float(196.0)         # 3 min song
-    assert __parse_duration("20") == float(20.0)            # 20 second song
-    assert __parse_duration("25:59") == float(1559.0)       # 26 min result
-    assert __parse_duration("25:59:59") == float(93599.0)   # 26 hour result
-    assert __parse_duration("likes") == float(0.0)          # bad values
-    assert __parse_duration("views") == float(0.0)
-    assert __parse_duration([1, 2, 3]) == float(0.0)
-    assert __parse_duration({"json": "data"}) == float(0.0)
+    assert _parse_duration("3:16") == float(196.0)         # 3 min song
+    assert _parse_duration("20") == float(20.0)            # 20 second song
+    assert _parse_duration("25:59") == float(1559.0)       # 26 min result
+    assert _parse_duration("25:59:59") == float(93599.0)   # 26 hour result
+    assert _parse_duration("likes") == float(0.0)          # bad values
+    assert _parse_duration("views") == float(0.0)
+    assert _parse_duration([1, 2, 3]) == float(0.0)
+    assert _parse_duration({"json": "data"}) == float(0.0)

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -5,10 +5,11 @@ def test_parse_duration():
     Test the duration parsing
     """
 
-    assert __parse_duration("20") == float(20.0)
-    assert __parse_duration("25:59:59") == float(93599.0)
-    assert __parse_duration("25:59") == float(1559.0)
-    assert __parse_duration("likes") == float(0.0)
+    assert __parse_duration("3:16") == float(196.0)         # 3 min song
+    assert __parse_duration("20") == float(20.0)            # 20 second song
+    assert __parse_duration("25:59") == float(1559.0)       # 26 min result
+    assert __parse_duration("25:59:59") == float(93599.0)   # 26 hour result
+    assert __parse_duration("likes") == float(0.0)          # bad values
     assert __parse_duration("views") == float(0.0)
     assert __parse_duration([1, 2, 3]) == float(0.0)
     assert __parse_duration({"json": "data"}) == float(0.0)


### PR DESCRIPTION
## Issue
The youtube search provider chokes on youtube results longer than 24 hours. Seen in #1110

The error looks something like this
```
ValueError: time data '25:22:47' does not match format '%H:%M:%S'
```

This is due to the scraped time conversion into seconds. `datetime.strptime' is trying to strip an absolute time (23:59:59 max) whereas the song duration is relative and reporting in maximum increments of hours. See: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes

 
## Fix

Use an interpreted relative time library [wroberts/pytimeparse](https://github.com/wroberts/pytimeparse) to convert to seconds


### Notes: 
Yes, a song longer than 24 hours is probably the wrong one and should be discarded, I will leave that up to the time delta filtering/fuzzing done in `provider.py`. I know I know, who wants a song longer than 24 hours? Beats me.
