### PR TITLE
fix disallowed chars matching for colons (:)

### DIFF
--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -152,7 +152,7 @@ class DownloadManager():
         #! double quotes (") and semi-colons (:) are also disallowed characters but we would
         #! like to retain their equivalents, so they aren't removed in the prior loop
         convertedFileName = convertedFileName.replace(
-            '"', "'").replace(': ', ' - ')
+            '"', "'").replace(':', '-')
 
         convertedFilePath = Path(".", f"{convertedFileName}.mp3")
 


### PR DESCRIPTION
Discovered by @netkenny as mentioned in #1104.

Colons (not followed by a space) in the song/artist name causes hangup at conversion since any colon in the filename is not allowed in windows.
