### PR TITLE
Return a length of 0 if no duration for the song has been found.

### DIFF
--- a/spotdl/search/provider.py
+++ b/spotdl/search/provider.py
@@ -73,6 +73,10 @@ ytmApiClient = YTMusic()
 
 
 def __parse_duration(duration: str) -> float:
+
+    # if duration is None:
+        # return 0
+
     if len(duration) > 5:
         padded = duration.rjust(8, '0')
         x = strptime(padded, '%H:%M:%S')

--- a/spotdl/search/provider.py
+++ b/spotdl/search/provider.py
@@ -74,8 +74,8 @@ ytmApiClient = YTMusic()
 
 def __parse_duration(duration: str) -> float:
 
-    # if duration is None:
-        # return 0
+    if duration is None:
+        return 0
 
     if len(duration) > 5:
         padded = duration.rjust(8, '0')


### PR DESCRIPTION
## Design
<!--- Describe the problem or feature in addition to a link to the issues. -->
Ytmusicapi, as of [0.13.1v](https://github.com/sigma67/ytmusicapi/issues/149), can now return `None` if no duration is found for the song. Where it would crash before.

## Approach
<!--- Describe your solution in around 50 words. Please be concise and specific. -->
My approach is to return `0` if no duration is found. This will make it very unlikely that this song will be downloaded, since we can't make an assumption on the duration of the song.

