### PR TITLE
Fix workflows

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,7 +6,6 @@ name: Upload Python Package
 on:
   release:
     types: 
-      - created
       - published
       
 jobs:

--- a/.github/workflows/spotify-downloader-ci.yml
+++ b/.github/workflows/spotify-downloader-ci.yml
@@ -3,11 +3,7 @@
 
 name: spotify-downloader-ci
 
-on:
-  push:
-    branches: [ master, dev ]
-  pull_request:
-    branches: [ master, dev ]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
It was running twice instead of once previously.
Created = "Non-Draft Release published"
Published = "Any release published"

Sources;
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onevent_nametypes
https://stackoverflow.com/questions/59319281/github-action-different-between-release-created-and-published