### PR TITLE
Run regressions on CI

### DIFF
--- a/.github/workflows/spotify-downloader-ci.yml
+++ b/.github/workflows/spotify-downloader-ci.yml
@@ -29,3 +29,22 @@ jobs:
           tox
         env:
           PLATFORM: ${{ matrix.platform }}
+
+  regressions:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          sudo add-apt-repository ppa:jonathonf/ffmpeg-4 -y
+          sudo apt-get update
+          sudo apt install ffmpeg -y
+          python -m pip install -e .[test]
+      - name: Run tests
+        run: |
+          pytest tests/regressions.py


### PR DESCRIPTION
This PR adds `tests/regressions.py` to CI. This runs just on Ubuntu on Python 3.8 - there are no mocks or stubs - the test just downloads songs that used to have a problem. The goal is to make sure that the problems will not come back.   
For now, there are only 2 songs but the list will grow in the future.