### PR TITLE
Colon error fix

### DIFF
--- a/spotdl/download/progressHandlers.py
+++ b/spotdl/download/progressHandlers.py
@@ -215,7 +215,7 @@ class DownloadTracker():
                 if disallowedChar in songName:
                     songName = songName.replace(disallowedChar, '')
 
-            songName = songName.replace('"', "'").replace(': ', ' - ')
+            songName = songName.replace('"', "'").replace(':', ' - ')
 
             self.saveFile = Path(songName + '.spotdlTrackingFile')
 


### PR DESCRIPTION
Fixes #1160 

Error was caused by "Rei - 4:19" (`https://open.spotify.com/track/5YlT9kW3aw6XIFB87Skv8A?si=D0gUq3DaTKWNRlFB_7nqxw`)

Caused by progressHandlers.py:ln218:
- `songName = songName.replace('"', "'").replace(': ', ' - ')`
- This replaces `: `  (colon followed by a space) which doesn't exist in the song's name.