### PR TITLE
Fixed TypeError when downloading tracks

### DIFF
--- a/spotdl/search/provider.py
+++ b/spotdl/search/provider.py
@@ -95,7 +95,7 @@ def __map_result_to_song_data(result: dict) -> dict:
         'name': result['title'],
         'type': result['resultType'],
         'artist': artists,
-        'length': __parse_duration(result['duration']),
+        'length': __parse_duration(result.get('duration', None)),
         'link': f'https://www.youtube.com/watch?v={video_id}',
         'position': 0
     }


### PR DESCRIPTION
YMusic sometimes returns results without duration, this commit makes sure that it does not break spotdl

track: https://open.spotify.com/track/3pjUyVbFmM96tYhSaKJwTt?si=EL8F3YB4SZqfJGU267O4-g

Error: 
![image](https://user-images.githubusercontent.com/42355410/107022153-55b32280-67a5-11eb-8870-c29064b954f5.png)
