### PR TITLE
Allow specifying output directory

### DIFF
--- a/spotdl/__main__.py
+++ b/spotdl/__main__.py
@@ -93,7 +93,7 @@ def console_entry_point():
     if arguments.path:
         if not os.path.isdir(arguments.path):
             sys.exit("The output directory doesn't exist.")
-        print(f"Will download to: {os.path.abspath(arguments.path)}", )
+        print(f"Will download to: {os.path.abspath(arguments.path)}")
         os.chdir(arguments.path)
 
     downloader = DownloadManager()

--- a/spotdl/__main__.py
+++ b/spotdl/__main__.py
@@ -1,5 +1,7 @@
 #! Basic necessities to get the CLI running
 import argparse
+import os
+import sys
 
 # ! The actual download stuff
 from spotdl.download.downloader import DownloadManager
@@ -88,6 +90,12 @@ def console_entry_point():
         clientSecret='0f02b7c483c04257984695007a4a8d5c'
     )
 
+    if arguments.path:
+        if not os.path.isdir(arguments.path):
+            sys.exit("The output directory doesn't exist.")
+        print(f"Will download to: {os.path.abspath(arguments.path)}", )
+        os.chdir(arguments.path)
+
     downloader = DownloadManager()
 
     for request in arguments.url:
@@ -136,7 +144,8 @@ def parse_arguments():
         description=help_notice,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("url", type=str, nargs="+")
+    parser.add_argument("url", type=str, nargs="+", help="URL to a song/album/playlist")
+    parser.add_argument("-o", "--output", help="Output directory path", dest="path")
 
     return parser.parse_args()
 


### PR DESCRIPTION
This is a very small change that'll allow specifying the output directory by specifying `-o` or `--output` argument.  
Some users were asking for it, and I find it also useful to me.