### PR TITLE
skip results  without videoId

### DIFF
--- a/spotdl/__init__.py
+++ b/spotdl/__init__.py
@@ -1,4 +1,4 @@
-from .__main__ import console_entry_point	
+from .__main__ import console_entry_point
 
 __all__ = [
     'console_entry_point',

--- a/spotdl/search/provider.py
+++ b/spotdl/search/provider.py
@@ -152,7 +152,7 @@ def search_and_order_ytm_results(songName: str, songArtists: List[str],
     linksWithMatchValue = {}
 
     for result in results:
-        # ! skip results without videoId, this happens if you are country restricted or 
+        # ! skip results without videoId, this happens if you are country restricted or
         # ! video is unavailabe
         if result.get('videoId') is None:
             continue

--- a/spotdl/search/provider.py
+++ b/spotdl/search/provider.py
@@ -89,7 +89,9 @@ def _parse_duration(duration: str) -> float:
 
 def _map_result_to_song_data(result: dict) -> dict:
     artists = ", ".join(map(lambda a: a['name'], result['artists']))
-    video_id = result.get('videoId')
+    video_id = result.get('videoId', None)
+    if video_id is None: 
+        return {}
     song_data = {
         'name': result['title'],
         'type': result['resultType'],
@@ -154,7 +156,7 @@ def search_and_order_ytm_results(songName: str, songArtists: List[str],
     for result in results:
         # ! skip results without videoId, this happens if you are country restricted or
         # ! video is unavailabe
-        if result.get('videoId') is None:
+        if result == {}:
             continue
 
         # ! If there are no common words b/w the spotify and YouTube Music name, the song

--- a/spotdl/search/provider.py
+++ b/spotdl/search/provider.py
@@ -90,7 +90,7 @@ def _parse_duration(duration: str) -> float:
 def _map_result_to_song_data(result: dict) -> dict:
     artists = ", ".join(map(lambda a: a['name'], result['artists']))
     video_id = result.get('videoId', None)
-    if video_id is None: 
+    if video_id is None:
         return {}
     song_data = {
         'name': result['title'],

--- a/spotdl/search/provider.py
+++ b/spotdl/search/provider.py
@@ -89,7 +89,7 @@ def _parse_duration(duration: str) -> float:
 
 def _map_result_to_song_data(result: dict) -> dict:
     artists = ", ".join(map(lambda a: a['name'], result['artists']))
-    video_id = result['videoId']
+    video_id = result.get('videoId')
     song_data = {
         'name': result['title'],
         'type': result['resultType'],
@@ -152,6 +152,11 @@ def search_and_order_ytm_results(songName: str, songArtists: List[str],
     linksWithMatchValue = {}
 
     for result in results:
+        # ! skip results without videoId, this happens if you are country restricted or 
+        # ! video is unavailabe
+        if result.get('videoId') is None:
+            continue
+
         # ! If there are no common words b/w the spotify and YouTube Music name, the song
         # ! is a wrong match (Like Ruelle - Madness being matched to Ruelle - Monster, it
         # ! happens without this conditional)


### PR DESCRIPTION
Results without videoId cause `pytube.exceptions.RegexMatchError: regex_search: could not find match for (?:v=|\/)([0-9A-Za-z_-]{11}).*`

fixes #1193 