### PR TITLE
setup: Use the proper name for beautifulsoup4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     mutagen
     ytmusicapi
     tqdm
-    bs4
+    beautifulsoup4
     requests
 python_requires = >=3.6
 packages = find:


### PR DESCRIPTION
`bs4` is just a metapackage to pull in `beautifulsoup4`, so not all distributions have it in their repositories.

Fixes: #1209 