### PR TITLE
ffmpeg executable path

### DIFF
--- a/spotdl/__main__.py
+++ b/spotdl/__main__.py
@@ -91,7 +91,7 @@ def console_entry_point():
     '''
     arguments = parse_arguments()
 
-    if ffmpeg.has_correct_version(arguments.ignore_ffmpeg_version) is False:
+    if ffmpeg.has_correct_version(arguments.ignore_ffmpeg_version, arguments.ffmpeg or "ffmpeg") is False:
         sys.exit(1)
 
     SpotifyClient.init(
@@ -105,7 +105,7 @@ def console_entry_point():
         print(f"Will download to: {os.path.abspath(arguments.path)}")
         os.chdir(arguments.path)
 
-    with DownloadManager() as downloader:
+    with DownloadManager(arguments.ffmpeg) as downloader:
 
         for request in arguments.url:
             if 'open.spotify.com' in request and 'track' in request:
@@ -158,6 +158,7 @@ def parse_arguments():
     )
     parser.add_argument("url", type=str, nargs="+", help="URL to a song/album/playlist")
     parser.add_argument("-o", "--output", help="Output directory path", dest="path")
+    parser.add_argument("-f", "--ffmpeg", help="Path to ffmpeg", dest="ffmpeg")
     parser.add_argument("--ignore-ffmpeg-version",
                         help="Ignore ffmpeg version", action="store_true")
 

--- a/spotdl/__main__.py
+++ b/spotdl/__main__.py
@@ -91,7 +91,10 @@ def console_entry_point():
     '''
     arguments = parse_arguments()
 
-    if ffmpeg.has_correct_version(arguments.ignore_ffmpeg_version, arguments.ffmpeg or "ffmpeg") is False:
+    if ffmpeg.has_correct_version(
+        arguments.ignore_ffmpeg_version,
+        arguments.ffmpeg or "ffmpeg"
+    ) is False:
         sys.exit(1)
 
     SpotifyClient.init(

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -33,7 +33,7 @@ class DownloadManager():
     # ! Big pool sizes on slow connections will lead to more incomplete downloads
     poolSize = 4
 
-    def __init__(self):
+    def __init__(self, ffmpeg_path: str = "ffmpeg"):
 
         # start a server for objects shared across processes
         self.displayManager = DisplayManager()
@@ -52,6 +52,9 @@ class DownloadManager():
         # ! thread pool executor is used to run blocking (CPU-bound) code from a thread
         self.thread_executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=self.poolSize)
+
+        # ! ffmpeg path
+        self.ffmpeg_path = ffmpeg_path
 
     def __enter__(self):
         return self
@@ -216,7 +219,8 @@ class DownloadManager():
             ffmpeg_success = await ffmpeg.convert(
                 trackAudioStream=trackAudioStream,
                 downloadedFilePath=downloadedFilePath,
-                convertedFilePath=convertedFilePath
+                convertedFilePath=convertedFilePath,
+                ffmpegPath=self.ffmpeg_path
             )
 
             if dispayProgressTracker:

--- a/spotdl/download/ffmpeg.py
+++ b/spotdl/download/ffmpeg.py
@@ -4,9 +4,9 @@ import sys
 import re
 
 
-def has_correct_version(skip_version_check: bool = False) -> bool:
+def has_correct_version(skip_version_check: bool = False, ffmpeg_path: str = "ffmpeg") -> bool:
     process = subprocess.Popen(
-        ['ffmpeg', '-version'],
+        [ffmpeg_path, '-version'],
         shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
 
@@ -32,7 +32,7 @@ def has_correct_version(skip_version_check: bool = False) -> bool:
     return True
 
 
-async def convert(trackAudioStream, downloadedFilePath, convertedFilePath) -> bool:
+async def convert(trackAudioStream, downloadedFilePath, convertedFilePath, ffmpegPath) -> bool:
     # convert downloaded file to MP3 with normalization
 
     # ! -af loudnorm=I=-7:LRA applies EBR 128 loudness normalization algorithm with
@@ -55,8 +55,11 @@ async def convert(trackAudioStream, downloadedFilePath, convertedFilePath) -> bo
     # ! sampled length of songs matches the actual length (i.e. a 5 min song won't display
     # ! as 47 seconds long in your music player, yeah that was an issue earlier.)
 
+    if ffmpegPath is None:
+        ffmpegPath = "ffmpeg"
+
     command = (
-        'ffmpeg -v quiet -y -i "%s" -acodec libmp3lame -abr true '
+        f'{ffmpegPath} -v quiet -y -i "%s" -acodec libmp3lame -abr true '
         f"-b:a {trackAudioStream.bitrate} "
         '-af "apad=pad_dur=2, dynaudnorm, loudnorm=I=-17" "%s"'
     )

--- a/spotdl/download/ffmpeg.py
+++ b/spotdl/download/ffmpeg.py
@@ -26,7 +26,7 @@ def has_correct_version(skip_version_check: bool = False, ffmpeg_path: str = "ff
         version = result.group(0).replace("ffmpeg version ", "")
 
         # remove all non numeric characters from string example: n4.3
-        version = re.sub(r"[^0-9]", "", version)
+        version = re.sub(r"[a-zA-Z]", "", version)
 
         if float(version) < 4.3:
             print(f"Your FFmpeg installation is too old ({version}), please update to 4.3+\n",

--- a/spotdl/download/ffmpeg.py
+++ b/spotdl/download/ffmpeg.py
@@ -24,6 +24,10 @@ def has_correct_version(skip_version_check: bool = False, ffmpeg_path: str = "ff
             return False
 
         version = result.group(0).replace("ffmpeg version ", "")
+
+        # remove all non numeric characters from string example: n4.3
+        version = re.sub(r"[^0-9]", "", version)
+
         if float(version) < 4.3:
             print(f"Your FFmpeg installation is too old ({version}), please update to 4.3+\n",
                   file=sys.stderr)

--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -25,7 +25,7 @@ def new_initialize(client_id, client_secret):
 def patch_dependencies(mocker, monkeypatch):
     """This is a helper fixture to patch out everything that shouldn't be called here"""
     monkeypatch.setattr(SpotifyClient, "init", new_initialize)
-    monkeypatch.setattr(DownloadManager, "__init__", lambda _: None)
+    monkeypatch.setattr(DownloadManager, "__init__", lambda *_: None)
     monkeypatch.setattr(ffmpeg, "has_correct_version", lambda *_: True)
     mocker.patch.object(DownloadManager, "download_single_song", autospec=True)
     mocker.patch.object(


### PR DESCRIPTION
Allows the user to specify the location of `ffmpeg.exe` or `ffmpeg` 

example usage: spotdl 'query' --ffmpeg /home/xnetcat/Desktop/ffmpeg

closes #1251