### PR TITLE
fixed version detection on linux

### DIFF
--- a/spotdl/download/ffmpeg.py
+++ b/spotdl/download/ffmpeg.py
@@ -10,7 +10,10 @@ def has_correct_version(skip_version_check: bool = False) -> bool:
         shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
 
-    proc_out, _ = process.communicate()
+    if sys.platform == 'win32':
+        proc_out, _ = process.communicate()
+    else:
+        _, proc_out = process.communicate()
 
     if process.returncode == 127:
         print("FFmpeg was not found, spotDL cannot continue.", file=sys.stderr)

--- a/spotdl/download/ffmpeg.py
+++ b/spotdl/download/ffmpeg.py
@@ -10,7 +10,6 @@ def has_correct_version(skip_version_check: bool = False) -> bool:
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        text=True,
         encoding="utf-8"
     )
 

--- a/spotdl/download/ffmpeg.py
+++ b/spotdl/download/ffmpeg.py
@@ -7,19 +7,21 @@ import re
 def has_correct_version(skip_version_check: bool = False) -> bool:
     process = subprocess.Popen(
         ['ffmpeg', '-version'],
-        shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8"
     )
 
-    proc_out, proc_err = process.communicate()
-
-    out = proc_out + proc_err
+    output = "".join(process.communicate())
 
     if process.returncode == 127:
         print("FFmpeg was not found, spotDL cannot continue.", file=sys.stderr)
         return False
 
     if skip_version_check is False:
-        result = re.search(r"ffmpeg version \w?(\d+\.)?(\d+)", out.decode("utf-8"))
+        result = re.search(r"ffmpeg version \w?(\d+\.)?(\d+)", output)
 
         if result is None:
             print("Your FFmpeg version couldn't be detected", file=sys.stderr)

--- a/spotdl/download/ffmpeg.py
+++ b/spotdl/download/ffmpeg.py
@@ -10,17 +10,16 @@ def has_correct_version(skip_version_check: bool = False) -> bool:
         shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
 
-    if sys.platform == 'win32':
-        proc_out, _ = process.communicate()
-    else:
-        _, proc_out = process.communicate()
+    proc_out, proc_err = process.communicate()
+
+    out = proc_out + proc_err
 
     if process.returncode == 127:
         print("FFmpeg was not found, spotDL cannot continue.", file=sys.stderr)
         return False
 
     if skip_version_check is False:
-        result = re.search(r"ffmpeg version \w?(\d+\.)?(\d+)", proc_out.decode("utf-8"))
+        result = re.search(r"ffmpeg version \w?(\d+\.)?(\d+)", out.decode("utf-8"))
 
         if result is None:
             print("Your FFmpeg version couldn't be detected", file=sys.stderr)


### PR DESCRIPTION
For some reason subprocess.Popopen returns tuple (proc_err, proc_out) instead of (proc_out, proc_err) on linux.

I have no clue why it's happening

Other way of fixing this suggested by @ndgnuh

```python
process = subprocess.Popen(["ffmpeg", "-version"], shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
proc_out = process.stdout.readlines()[0]
```

`process.communicate()` return
![image](https://user-images.githubusercontent.com/42355410/113888899-0730fd00-97c3-11eb-8dad-df6c1f29c796.png)
