### PR TITLE
Improved ffmpeg installation for ci

### DIFF
--- a/.github/workflows/spotify-downloader-ci.yml
+++ b/.github/workflows/spotify-downloader-ci.yml
@@ -73,12 +73,7 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
-          wget -nv https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
-          wget -nv https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz.md5
-          tar xf ffmpeg-release-amd64-static.tar.xz
-          cd $(ls -d ffmpeg*/ | head -n 1)
-          sudo mv ffmpeg ffprobe /usr/local/bin/
-          cd ..
+          sudo apt install ffmpeg -y
           ffmpeg -version
           python -m pip install -e .[test]
       - name: Run tests


### PR DESCRIPTION
john van sickle website is sometimes not working, since we are using ubuntu 20.04 the default ffmpeg version is 4.2 it's a bit outdated but should work just fine