### PR TITLE
Remove FFmpeg normalization causing "quiet" songs.

### DIFF
--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -7,6 +7,7 @@ import sys
 import traceback
 
 from pathlib import Path
+
 # ! The following are not used, they are just here for static typechecking with mypy
 from typing import List
 from urllib.request import urlopen
@@ -29,7 +30,8 @@ from spotdl.download import ffmpeg
 # === The Download Manager (the tyrannical boss lady/guy) ===
 # ===========================================================
 
-class DownloadManager():
+
+class DownloadManager:
     # ! Big pool sizes on slow connections will lead to more incomplete downloads
     poolSize = 4
 
@@ -51,7 +53,8 @@ class DownloadManager():
 
         # ! thread pool executor is used to run blocking (CPU-bound) code from a thread
         self.thread_executor = concurrent.futures.ThreadPoolExecutor(
-            max_workers=self.poolSize)
+            max_workers=self.poolSize
+        )
 
         # ! ffmpeg path
         self.ffmpeg_path = ffmpeg_path
@@ -63,13 +66,13 @@ class DownloadManager():
         self.displayManager.close()
 
     def download_single_song(self, songObj: SongObj) -> None:
-        '''
+        """
         `songObj` `song` : song to be downloaded
 
         RETURNS `~`
 
         downloads the given song
-        '''
+        """
 
         self.downloadTracker.clear()
         self.downloadTracker.load_song_list([songObj])
@@ -79,13 +82,13 @@ class DownloadManager():
         self._download_asynchronously([songObj])
 
     def download_multiple_songs(self, songObjList: List[SongObj]) -> None:
-        '''
+        """
         `list<songObj>` `songObjList` : list of songs to be downloaded
 
         RETURNS `~`
 
         downloads the given songs in parallel
-        '''
+        """
 
         self.downloadTracker.clear()
         self.downloadTracker.load_song_list(songObjList)
@@ -95,13 +98,13 @@ class DownloadManager():
         self._download_asynchronously(songObjList)
 
     def resume_download_from_tracking_file(self, trackingFilePath: str) -> None:
-        '''
+        """
         `str` `trackingFilePath` : path to a .spotdlTrackingFile
 
         RETURNS `~`
 
         downloads songs present on the .spotdlTrackingFile in parallel
-        '''
+        """
 
         self.downloadTracker.clear()
         self.downloadTracker.load_tracking_file(trackingFilePath)
@@ -113,16 +116,15 @@ class DownloadManager():
         self._download_asynchronously(songObjList)
 
     async def download_song(self, songObj: SongObj) -> None:
-        '''
+        """
         `songObj` `songObj` : song to be downloaded
 
         RETURNS `~`
 
         Downloads, Converts, Normalizes song & embeds metadata as ID3 tags.
-        '''
+        """
 
-        dispayProgressTracker = self.displayManager.new_progress_tracker(
-            songObj)
+        dispayProgressTracker = self.displayManager.new_progress_tracker(songObj)
 
         # ! since most errors are expected to happen within this function, we wrap in
         # ! exception catcher to prevent blocking on multiple downloads
@@ -135,41 +137,38 @@ class DownloadManager():
             # ! platform agnostic
 
             # Create a .\Temp folder if not present
-            tempFolder = Path('.', 'Temp')
+            tempFolder = Path(".", "Temp")
 
             if not tempFolder.exists():
                 tempFolder.mkdir()
 
             # build file name of converted file
-            artistStr = ''
+            artistStr = ""
 
             # ! we eliminate contributing artist names that are also in the song name, else we
             # ! would end up with things like 'Jetta, Mastubs - I'd love to change the world
             # ! (Mastubs REMIX).mp3' which is kinda an odd file name.
             for artist in songObj.get_contributing_artists():
                 if artist.lower() not in songObj.get_song_name().lower():
-                    artistStr += artist + ', '
+                    artistStr += artist + ", "
 
             # make sure that main artist is included in artistStr even if they
             # are in the song name, for example
             # Lil Baby - Never Recover (Lil Baby & Gunna, Drake).mp3
             if songObj.get_contributing_artists()[0].lower() not in artistStr.lower():
-                artistStr = songObj.get_contributing_artists()[0] + ', ' + artistStr
+                artistStr = songObj.get_contributing_artists()[0] + ", " + artistStr
 
             # ! the ...[:-2] is to avoid the last ', ' appended to artistStr
-            convertedFileName = artistStr[:-2] + \
-                ' - ' + songObj.get_song_name()
+            convertedFileName = artistStr[:-2] + " - " + songObj.get_song_name()
 
             # ! this is windows specific (disallowed chars)
-            for disallowedChar in ['/', '?', '\\', '*', '|', '<', '>']:
+            for disallowedChar in ["/", "?", "\\", "*", "|", "<", ">"]:
                 if disallowedChar in convertedFileName:
-                    convertedFileName = convertedFileName.replace(
-                        disallowedChar, '')
+                    convertedFileName = convertedFileName.replace(disallowedChar, "")
 
             # ! double quotes (") and semi-colons (:) are also disallowed characters but we would
             # ! like to retain their equivalents, so they aren't removed in the prior loop
-            convertedFileName = convertedFileName.replace(
-                '"', "'").replace(':', '-')
+            convertedFileName = convertedFileName.replace('"', "'").replace(":", "-")
 
             convertedFilePath = Path(".", f"{convertedFileName}.mp3")
 
@@ -188,24 +187,27 @@ class DownloadManager():
             if dispayProgressTracker:
                 youtubeHandler = YouTube(
                     url=songObj.get_youtube_link(),
-                    on_progress_callback=dispayProgressTracker.pytube_progress_hook
+                    on_progress_callback=dispayProgressTracker.pytube_progress_hook,
                 )
 
             else:
                 youtubeHandler = YouTube(songObj.get_youtube_link())
 
-            trackAudioStream = youtubeHandler.streams.filter(
-                only_audio=True).order_by('bitrate').last()
+            trackAudioStream = (
+                youtubeHandler.streams.filter(only_audio=True)
+                .order_by("bitrate")
+                .last()
+            )
             if not trackAudioStream:
-                print(f"Unable to get audio stream for \"{songObj.get_song_name()}\" "
-                      f"by \"{songObj.get_contributing_artists()[0]}\" "
-                      f"from video \"{songObj.get_youtube_link()}\"")
+                print(
+                    f'Unable to get audio stream for "{songObj.get_song_name()}" '
+                    f'by "{songObj.get_contributing_artists()[0]}" '
+                    f'from video "{songObj.get_youtube_link()}"'
+                )
                 return None
 
             downloadedFilePathString = await self._download_from_youtube(
-                convertedFileName,
-                tempFolder,
-                trackAudioStream
+                convertedFileName, tempFolder, trackAudioStream
             )
 
             if downloadedFilePathString is None:
@@ -220,7 +222,7 @@ class DownloadManager():
                 trackAudioStream=trackAudioStream,
                 downloadedFilePath=downloadedFilePath,
                 convertedFilePath=convertedFilePath,
-                ffmpegPath=self.ffmpeg_path
+                ffmpegPath=self.ffmpeg_path,
             )
 
             if dispayProgressTracker:
@@ -259,48 +261,46 @@ class DownloadManager():
         # ! Get rid of all existing ID3 tags (if any exist)
         audioFile.delete()
         # ! song name
-        audioFile['title'] = songObj.get_song_name()
-        audioFile['titlesort'] = songObj.get_song_name()
+        audioFile["title"] = songObj.get_song_name()
+        audioFile["titlesort"] = songObj.get_song_name()
         # ! track number
-        audioFile['tracknumber'] = str(songObj.get_track_number())
+        audioFile["tracknumber"] = str(songObj.get_track_number())
         # ! disc number
-        audioFile['discnumber'] = str(songObj.get_disc_number())
+        audioFile["discnumber"] = str(songObj.get_disc_number())
         # ! genres (pretty pointless if you ask me)
         # ! we only apply the first available genre as ID3 v2.3 doesn't support multiple
         # ! genres and ~80% of the world PC's run Windows - an OS with no ID3 v2.4 support
         genres = songObj.get_genres()
         if len(genres) > 0:
-            audioFile['genre'] = genres[0]
+            audioFile["genre"] = genres[0]
         # ! all involved artists
-        audioFile['artist'] = songObj.get_contributing_artists()
+        audioFile["artist"] = songObj.get_contributing_artists()
         # ! album name
-        audioFile['album'] = songObj.get_album_name()
+        audioFile["album"] = songObj.get_album_name()
         # ! album artist (all of 'em)
-        audioFile['albumartist'] = songObj.get_album_artists()
+        audioFile["albumartist"] = songObj.get_album_artists()
         # ! album release date (to what ever precision available)
-        audioFile['date'] = songObj.get_album_release()
-        audioFile['originaldate'] = songObj.get_album_release()
+        audioFile["date"] = songObj.get_album_release()
+        audioFile["originaldate"] = songObj.get_album_release()
         # ! save as both ID3 v2.3 & v2.4 as v2.3 isn't fully features and
         # ! windows doesn't support v2.4 until later versions of Win10
         audioFile.save(v2_version=3)
         # ! setting the album art
         audioFile = ID3(convertedFilePath)
         rawAlbumArt = urlopen(songObj.get_album_cover_url()).read()
-        audioFile['APIC'] = AlbumCover(
-            encoding=3,
-            mime='image/jpeg',
-            type=3,
-            desc='Cover',
-            data=rawAlbumArt
+        audioFile["APIC"] = AlbumCover(
+            encoding=3, mime="image/jpeg", type=3, desc="Cover", data=rawAlbumArt
         )
         # ! setting the lyrics
         lyrics = songObj.get_lyrics()
-        USLTOutput = USLT(encoding=3, lang=u'eng', desc=u'desc', text=lyrics)
+        USLTOutput = USLT(encoding=3, lang="eng", desc="desc", text=lyrics)
         audioFile["USLT::'eng'"] = USLTOutput
 
         audioFile.save(v2_version=3)
 
-    async def _download_from_youtube(self, convertedFileName, tempFolder, trackAudioStream):
+    async def _download_from_youtube(
+        self, convertedFileName, tempFolder, trackAudioStream
+    ):
         # ! The following function calls blocking code, which would block whole event loop.
         # ! Therefore it has to be called in a separate thread via ThreadPoolExecutor. This
         # ! is not a problem, since GIL is released for the I/O operations, so it shouldn't
@@ -310,7 +310,7 @@ class DownloadManager():
             self._perform_audio_download,
             convertedFileName,
             tempFolder,
-            trackAudioStream
+            trackAudioStream,
         )
 
     def _perform_audio_download(self, convertedFileName, tempFolder, trackAudioStream):
@@ -319,9 +319,7 @@ class DownloadManager():
             # ! pyTube will save the song in .\Temp\$songName.mp4 or .webm,
             # ! it doesn't save as '.mp3'
             downloadedFilePath = trackAudioStream.download(
-                output_path=tempFolder,
-                filename=convertedFileName,
-                skip_existing=False
+                output_path=tempFolder, filename=convertedFileName, skip_existing=False
             )
             return downloadedFilePath
         except:  # noqa:E722
@@ -329,7 +327,7 @@ class DownloadManager():
             # ! downloadTrackers download queue and all is well...
             # !
             # ! None is again used as a convenient exit
-            tempFiles = Path(tempFolder).glob(f'{convertedFileName}.*')
+            tempFiles = Path(tempFolder).glob(f"{convertedFileName}.*")
             for tempFile in tempFiles:
                 tempFile.unlink()
             return None

--- a/spotdl/download/ffmpeg.py
+++ b/spotdl/download/ffmpeg.py
@@ -4,13 +4,15 @@ import sys
 import re
 
 
-def has_correct_version(skip_version_check: bool = False, ffmpeg_path: str = "ffmpeg") -> bool:
+def has_correct_version(
+    skip_version_check: bool = False, ffmpeg_path: str = "ffmpeg"
+) -> bool:
     try:
         process = subprocess.Popen(
-            ['ffmpeg', '-version'],
+            ["ffmpeg", "-version"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            encoding="utf-8"
+            encoding="utf-8",
         )
     except FileNotFoundError:
         print("FFmpeg was not found, spotDL cannot continue.", file=sys.stderr)
@@ -31,30 +33,20 @@ def has_correct_version(skip_version_check: bool = False, ffmpeg_path: str = "ff
         version = re.sub(r"[a-zA-Z]", "", version)
 
         if float(version) < 4.3:
-            print(f"Your FFmpeg installation is too old ({version}), please update to 4.3+\n",
-                  file=sys.stderr)
+            print(
+                f"Your FFmpeg installation is too old ({version}), please update to 4.3+\n",
+                file=sys.stderr,
+            )
             return False
 
     return True
 
 
-async def convert(trackAudioStream, downloadedFilePath, convertedFilePath, ffmpegPath) -> bool:
-    # convert downloaded file to MP3 with normalization
+async def convert(
+    trackAudioStream, downloadedFilePath, convertedFilePath, ffmpegPath
+) -> bool:
+    # convert downloaded file to MP3
 
-    # ! -af loudnorm=I=-7:LRA applies EBR 128 loudness normalization algorithm with
-    # ! intergrated loudness target (I) set to -17, using values lower than -15
-    # ! causes 'pumping' i.e. rhythmic variation in loudness that should not
-    # ! exist -loud parts exaggerate, soft parts left alone.
-    # !
-    # ! dynaudnorm applies dynamic non-linear RMS based normalization, this is what
-    # ! actually normalized the audio. The loudnorm filter just makes the apparent
-    # ! loudness constant
-    # !
-    # ! apad=pad_dur=2 adds 2 seconds of silence toward the end of the track, this is
-    # ! done because the loudnorm filter clips/cuts/deletes the last 1-2 seconds on
-    # ! occasion especially if the song is EDM-like, so we add a few extra seconds to
-    # ! combat that.
-    # !
     # ! -acodec libmp3lame sets the encoded to 'libmp3lame' which is far better
     # ! than the default 'mp3_mf', '-abr true' automatically determines and passes the
     # ! audio encoding bitrate to the filters and encoder. This ensures that the
@@ -67,7 +59,7 @@ async def convert(trackAudioStream, downloadedFilePath, convertedFilePath, ffmpe
     command = (
         f'{ffmpegPath} -v quiet -y -i "%s" -acodec libmp3lame -abr true '
         f"-b:a {trackAudioStream.bitrate} "
-        '-af "apad=pad_dur=2, dynaudnorm, loudnorm=I=-17" "%s"'
+        f'"%s"'
     )
 
     # ! bash/ffmpeg on Unix systems need to have excape char (\) for special characters: \$
@@ -96,7 +88,7 @@ async def convert(trackAudioStream, downloadedFilePath, convertedFilePath, ffmpe
     if process.returncode != 0:
         message = (
             f"ffmpeg returned an error ({process.returncode})"
-            f"\nthe ffmpeg command was \"{formattedCommand}\""
+            f'\nthe ffmpeg command was "{formattedCommand}"'
             "\nffmpeg gave this output:"
             "\n=====\n"
             f"{proc_err.decode('utf-8')}"

--- a/spotdl/download/ffmpeg.py
+++ b/spotdl/download/ffmpeg.py
@@ -57,9 +57,7 @@ async def convert(
         ffmpegPath = "ffmpeg"
 
     command = (
-        f'{ffmpegPath} -v quiet -y -i "%s" -acodec libmp3lame -abr true '
-        f"-q:a 0 "
-        f'"%s"'
+        f'{ffmpegPath} -v quiet -y -i "%s" -acodec libmp3lame -abr true -q:a 0 "%s"'
     )
 
     # ! bash/ffmpeg on Unix systems need to have excape char (\) for special characters: \$

--- a/spotdl/download/ffmpeg.py
+++ b/spotdl/download/ffmpeg.py
@@ -58,7 +58,7 @@ async def convert(
 
     command = (
         f'{ffmpegPath} -v quiet -y -i "%s" -acodec libmp3lame -abr true '
-        f"-b:a {trackAudioStream.bitrate} "
+        f"-q:a 0 "
         f'"%s"'
     )
 


### PR DESCRIPTION
# Title
Audio downloaded with spotdl is relatively quiet.

## Description
Audio normalization flags in the FFmpeg command reduces actual song loudness by almost 50%

## Motivation and Context
dr.boaf on discord originally voiced the issue and I too took notice of it. Removing the normalization flags causes the converted audio to match closer to the actual song. The normalization causes the song to be very dull and can be very apparent in certain conditions. I believe @MikhailZex originally introduced the flags. Could you expand on the usage and purpose?

## Testing / Screenshots (if appropriate)
Subject: Tristam - Over the Edge
![image](https://user-images.githubusercontent.com/44987569/116021480-e1528780-a60d-11eb-8503-360f1f01f07e.png)
_The absence of apad_dir also makes the song the exact same length_


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
