### PR TITLE
Use ffmpeg_path to check for version

### DIFF
--- a/spotdl/download/ffmpeg.py
+++ b/spotdl/download/ffmpeg.py
@@ -9,7 +9,7 @@ def has_correct_version(
 ) -> bool:
     try:
         process = subprocess.Popen(
-            ["ffmpeg", "-version"],
+            [ffmpeg_path, "-version"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             encoding="utf-8",


### PR DESCRIPTION
# Use ffmpeg_path to check for version
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Line 12 in `ffmpeg.py` didn't use the ffmpeg_path variable, leading to an `FFmpeg was not found, spotDL cannot continue.` error when the path was specified through the `--ffmpeg` flag.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to #1251, fixes a bug that arose in #1252 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bugfix error caused by not reading `ffmpeg_path` variable when specified

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
