### PR TITLE
Handle YouTube results without links

### DIFF
--- a/spotdl/search/audioProvider.py
+++ b/spotdl/search/audioProvider.py
@@ -166,7 +166,8 @@ def search_and_get_best_match(
         if len(isrcResults) == 1:
             isrcResult = isrcResults[0]
 
-            if isrcResult is not None:
+            # !Some YouTube results don't provide a 'link'
+            if isrcResult is not None and 'link' in isrcResult:
                 return isrcResult["link"]
 
     songTitle = create_song_title(songName, songArtists)

--- a/spotdl/search/audioProvider.py
+++ b/spotdl/search/audioProvider.py
@@ -167,7 +167,7 @@ def search_and_get_best_match(
             isrcResult = isrcResults[0]
 
             # !Some YouTube results don't provide a 'link'
-            if isrcResult is not None and 'link' in isrcResult:
+            if isrcResult is not None and "link" in isrcResult:
                 return isrcResult["link"]
 
     songTitle = create_song_title(songName, songArtists)


### PR DESCRIPTION
# Title
Handle YouTube results without links

## Description
handles results without 'link' provided by skipping them.

This pr is based on @MikhailZex [commit](https://github.com/MikhailZex/spotify-downloader/commit/133940b7d5c7b1b213b9456b74ce77c7d149881a). I am opening PR since he is busy rn

## Related Issue
#1337

## Motivation and Context
some YouTube results (isrcResult, audioProvider.pyL:170) do not even
contain 'link' as a key. This case is not handled and will error out.

## How Has This Been Tested?
pytest

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
