### PR TITLE
bugfix: fixed opus download

### DIFF
--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -164,6 +164,8 @@ class DownloadManager:
 
             if self.arguments["output_format"] == "m4a":
                 ytdl_format = "bestaudio[ext=m4a]"
+            elif self.arguments["output_format"] == "opus":
+                ytdl_format = "bestaudio[ext=webm]"
             else:
                 ytdl_format = "bestaudio"
 


### PR DESCRIPTION
# Title
fixed opus download

## Description
specify webm extension when downloading opus

## Related Issue
![image](https://user-images.githubusercontent.com/42355410/127376296-0d1ae43a-c65b-4ffa-8b07-c9915f0ab216.png)


## Motivation and Context
webm extension wasn't specified when using opus as output format

## How Has This Been Tested?
yeah

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
