### PR TITLE
bugfix: don't add cover if spotify does not provide album cover

### DIFF
--- a/spotdl/download/embed_metadata.py
+++ b/spotdl/download/embed_metadata.py
@@ -143,10 +143,11 @@ def _embed_mp3_metadata(audio_file, song_object: SongObject):
 def _embed_mp3_cover(audio_file, song_object, converted_file_path):
     # ! setting the album art
     audio_file = ID3(converted_file_path)
-    rawAlbumArt = urlopen(song_object.album_cover_url).read()
-    audio_file["APIC"] = AlbumCover(
-        encoding=3, mime="image/jpeg", type=3, desc="Cover", data=rawAlbumArt
-    )
+    if song_object.album_cover_url:
+        rawAlbumArt = urlopen(song_object.album_cover_url).read()
+        audio_file["APIC"] = AlbumCover(
+            encoding=3, mime="image/jpeg", type=3, desc="Cover", data=rawAlbumArt
+        )
 
     return audio_file
 
@@ -178,15 +179,16 @@ def _embed_m4a_metadata(audio_file, song_object: SongObject):
 
     # Explicit values: Dirty: 4, Clean: 2, None: 0
     audio_file[M4A_TAG_PRESET["explicit"]] = (0,)
-    try:
-        audio_file[M4A_TAG_PRESET["albumart"]] = [
-            MP4Cover(
-                urlopen(song_object.album_cover_url).read(),
-                imageformat=MP4Cover.FORMAT_JPEG,
-            )
-        ]
-    except IndexError:
-        pass
+    if song_object.album_cover_url:
+        try:
+            audio_file[M4A_TAG_PRESET["albumart"]] = [
+                MP4Cover(
+                    urlopen(song_object.album_cover_url).read(),
+                    imageformat=MP4Cover.FORMAT_JPEG,
+                )
+            ]
+        except IndexError:
+            pass
 
     return audio_file
 
@@ -261,6 +263,9 @@ def _embed_ogg_metadata(audio_file, song_object: SongObject):
 
 
 def _embed_cover(audio_file, song_object, encoding):
+    if song_object.album_cover_url is None:
+        return audio_file
+
     image = Picture()
     image.type = 3
     image.desc = "Cover"

--- a/spotdl/search/song_object.py
+++ b/spotdl/search/song_object.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 
 class SongObject:
@@ -141,12 +141,17 @@ class SongObject:
     # ! Utilities for genuine use and also for metadata freaks:
 
     @property
-    def album_cover_url(self) -> str:
+    def album_cover_url(self) -> Optional[str]:
         """
         returns url of the biggest album art image available.
         """
 
-        return self._raw_track_meta["album"]["images"][0]["url"]
+        images = self._raw_track_meta["album"]["images"]
+
+        if len(images) > 0:
+            return images[0]["url"]
+
+        return None
 
     @property
     def data_dump(self) -> dict:


### PR DESCRIPTION
# Title
don't add cover if spotify does not provide album cover

## Description
some songs don't have album cover art 

## Related Issue
![image](https://user-images.githubusercontent.com/42355410/133926777-55be2515-d5fb-4819-9dc2-35fb628481ab.png)


## Motivation and Context
spotdl was crashing when there wasn't cover art

## How Has This Been Tested?
gh actions

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
