### PR TITLE
bugfix: replace rapidfuzz with thefuzz

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,8 @@ install_requires =
     spotipy >= 2.19.0
     pytube >= 11.0.0
     rich
-    rapidfuzz
+    thefuzz
+    thefuzz[speedup]
     mutagen
     ytmusicapi
     yt-dlp

--- a/spotdl/providers/provider_utils.py
+++ b/spotdl/providers/provider_utils.py
@@ -1,14 +1,14 @@
 import requests
 
 from typing import List
-from rapidfuzz import fuzz
+from thefuzz import fuzz
 from bs4 import BeautifulSoup
 from pathlib import Path
 
 
 def _match_percentage(str1: str, str2: str, score_cutoff: float = 0) -> float:
     """
-    A wrapper around `rapidfuzz.fuzz.partial_ratio` to handle UTF-8 encoded
+    A wrapper around `thefuzz.fuzz.partial_ratio` to handle UTF-8 encoded
     emojis that usually cause errors
 
     `str` `str1` : a random sentence
@@ -21,7 +21,12 @@ def _match_percentage(str1: str, str2: str, score_cutoff: float = 0) -> float:
 
     # ! this will throw an error if either string contains a UTF-8 encoded emoji
     try:
-        return fuzz.partial_ratio(str1, str2, score_cutoff=score_cutoff)
+        partial_ratio = fuzz.partial_ratio(str1, str2)
+
+        if partial_ratio < score_cutoff:
+            return 0
+
+        return partial_ratio
 
     # ! we build new strings that contain only alphanumerical characters and spaces
     # ! and return the partial_ratio of that
@@ -38,7 +43,12 @@ def _match_percentage(str1: str, str2: str, score_cutoff: float = 0) -> float:
             if each_letter.isalnum() or each_letter.isspace()
         )
 
-        return fuzz.partial_ratio(new_str1, new_str2, score_cutoff=score_cutoff)
+        partial_ratio = fuzz.partial_ratio(new_str1, new_str2)
+
+        if partial_ratio < score_cutoff:
+            return 0
+
+        return partial_ratio
 
 
 def _parse_duration(duration: str) -> float:


### PR DESCRIPTION
# Title
replace rapidfuzz with thefuzz

## Description
replace rapidfuzz with thefuzz

## Related Issue
![image](https://user-images.githubusercontent.com/42355410/136166617-d158dc52-800f-43de-91ef-397629d49846.png)


## Motivation and Context
rapdifuzz requires additional build dependencies on python 3.10

## How Has This Been Tested?
pytest

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
