### PR TITLE
Fix custom youtube url parsing

### DIFF
--- a/spotdl/parsers/query_parser.py
+++ b/spotdl/parsers/query_parser.py
@@ -49,14 +49,14 @@ def parse_request(
 ) -> List[SongObject]:
     song_list: List[SongObject] = []
     if (
-        "youtube.com/watch?v=" in request
+        ("youtube.com/watch?v=" in request or "youtu.be/" in request)
         and "open.spotify.com" in request
         and "track" in request
         and "|" in request
     ):
         urls = request.split("|")
 
-        if len(urls) <= 1 or "youtube" not in urls[0] or "spotify" not in urls[1]:
+        if len(urls) <= 1 or "youtu" not in urls[0] or "spotify" not in urls[1]:
             print("Incorrect format used, please use YouTubeURL|SpotifyURL")
         else:
             print("Fetching YouTube video with spotify metadata")


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
# Fix Custom YT URL Parsing

## Description
<!--- Describe your changes in detail -->
When downloading using a custom url, i.e `spotdl "yt-url|spotify-url"`, spotDL didn't match youtube urls of type `https://youtu.be/S19UcWdOA-I`.


## How Has This Been Tested?
pytest (python 3.9)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
