### PR TITLE
Fix bug caused by fienames starting with -

### DIFF
--- a/spotdl/download/ffmpeg.py
+++ b/spotdl/download/ffmpeg.py
@@ -61,8 +61,8 @@ async def convert(
     # ! sampled length of songs matches the actual length (i.e. a 5 min song won't display
     # ! as 47 seconds long in your music player, yeah that was an issue earlier.)
 
-    downloaded_file_path = str(downloaded_file_path)
-    converted_file_path = str(converted_file_path)
+    downloaded_file_path = str(downloaded_file_path.absolute())
+    converted_file_path = str(converted_file_path.absolute())
 
     formats = {
         "mp3": ["-codec:a", "libmp3lame"],


### PR DESCRIPTION
# Fix bug caused by filenames stating with -
<!--- Provide a general summary of your changes in the Title above -->

## Description
If a filename stats with a `-`, ffmpeg recognizes it as a command.
Can be fixed by either using the absolute path or prepending a `./` 
<!--- Describe your changes in detail -->

## Related Issue
This issue was reported via an email.
[traceback](https://pastebin.com/ZWbeUwkb)
To reproduce:
`spotdl https://open.spotify.com/track/2WyvZcEnyjGhUPLHv7ZWUf`
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
pytest (python 3.9)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
