### PR TITLE
Fix #1433

### DIFF
--- a/spotdl/console/__init__.py
+++ b/spotdl/console/__init__.py
@@ -23,7 +23,7 @@ def console_entry_point():
     if arguments.ffmpeg:
         args_dict['ffmpeg'] = str(Path(arguments.ffmpeg).absolute())
     else:
-        args_dict['ffmpeg'] = "ffmpeg" 
+        args_dict['ffmpeg'] = "ffmpeg"
 
     # Check if ffmpeg has correct version, if not exit
     if (

--- a/spotdl/console/__init__.py
+++ b/spotdl/console/__init__.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from pathlib import Path
 import signal
 
 from spotdl.download import ffmpeg, DownloadManager
@@ -19,10 +20,15 @@ def console_entry_point():
     # Convert arguments to dict
     args_dict = vars(arguments)
 
+    if arguments.ffmpeg:
+        args_dict['ffmpeg'] = str(Path(arguments.ffmpeg).absolute())
+    else:
+        args_dict['ffmpeg'] = "ffmpeg" 
+
     # Check if ffmpeg has correct version, if not exit
     if (
         ffmpeg.has_correct_version(
-            arguments.ignore_ffmpeg_version, arguments.ffmpeg or "ffmpeg"
+            arguments.ignore_ffmpeg_version, args_dict['ffmpeg']
         )
         is False
     ):


### PR DESCRIPTION
# Fix #1433 
<!--- Provide a general summary of your changes in the Title above -->

## Description
Since `spotdl` uses `os.chdir` to change the download location, providing
a relative path as an argument to `--ffmpeg` causes it to look for ffmpeg
in the incorrect location, i.e `arguments.ffmpeg` realtive to the directory we
change to.

The fix is simple, use absolute path to ffmpeg before we change the working directory.
<!--- Describe your changes in detail -->

## Related Issue
#1433 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
pytest (python 3.9)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
