### PR TITLE
fix output bitrate for lossy codecs

### DIFF
--- a/spotdl/download/ffmpeg.py
+++ b/spotdl/download/ffmpeg.py
@@ -69,16 +69,31 @@ async def convert(
         "flac": ["-codec:a", "flac"],
         "ogg": ["-codec:a", "libvorbis"],
         "opus": ["-vn", "-c:a", "copy"]
-        if downloaded_file_path.endswith(".opus")
+        if downloaded_file_path.endswith(".webm")
         else ["-c:a", "libopus"],
         "m4a": ["-codec:a", "aac", "-vn"],
         "wav": [],
     }
 
+    bitrates = {
+        "mp3": ["-q:a", "0"],
+        "flac": [],
+        "ogg": ["-q:a", "5"],
+        "opus": []
+        if downloaded_file_path.endswith(".webm")
+        else ["-b:a", "160K"],
+        "m4a": []
+        if downloaded_file_path.endswith(".m4a")
+        else ["-b:a", "160K"],
+        "wav": [],
+    }
+
     if output_format is None:
         output_format_command = formats["mp3"]
+        output_bitrate = bitrates["mp3"]
     else:
         output_format_command = formats[output_format]
+        output_bitrate = bitrates[output_format]
 
     if ffmpeg_path is None:
         ffmpeg_path = "ffmpeg"
@@ -89,8 +104,7 @@ async def convert(
         *output_format_command,
         "-abr",
         "true",
-        "-q:a",
-        "0",
+        *output_bitrate,
         "-v",
         "debug",
         converted_file_path,


### PR DESCRIPTION
# fix output bitrate for lossy codecs
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add per-codec definitions for setting the target bitrate for transcodes with ffmpeg.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/spotDL/spotify-downloader/issues/1438
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This patch is necessary because the previous behavior resulted in unnecessarily low quality output files for some formats.

## How Has This Been Tested?
Running spotdl on a sample track for each format using `python -m spotdl` in my git folder

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
