### PR TITLE
use path_template to generate m3u paths only if path template is present

### DIFF
--- a/spotdl/search/song_gatherer.py
+++ b/spotdl/search/song_gatherer.py
@@ -192,7 +192,10 @@ def from_album(
             )
 
             if generate_m3u:
-                file_path = _parse_path_template(path_template, song, output_format)
+                if path_template:
+                    file_path = _parse_path_template(path_template, song, output_format)
+                else:
+                    file_path = _get_converted_file_path(song, output_format)
 
                 return song, f"{file_path}\n"
 
@@ -302,7 +305,10 @@ def from_playlist(
             )
 
             if generate_m3u:
-                file_path = _parse_path_template(path_template, song, output_format)
+                if path_template:
+                    file_path = _parse_path_template(path_template, song, output_format)
+                else:
+                    file_path = _get_converted_file_path(song, output_format)
 
                 return song, f"{file_path}\n"
 


### PR DESCRIPTION
# Title
use path_template to generate m3u paths only if path template is present

## Description
use path_template to generate m3u paths only if path template is present

## Related Issue
#1441

## Motivation and Context
use path_template to generate m3u paths only if path template is present

## How Has This Been Tested?
wasn't

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
