### PR TITLE
Small QoL change to easily see failed tracks

### DIFF
--- a/spotdl/search/song_gatherer.py
+++ b/spotdl/search/song_gatherer.py
@@ -85,7 +85,7 @@ def from_spotify_url(
 
     # Check if we found youtube url
     if youtube_link is None:
-        print("Could not match any of the results on YouTube. Skipping")
+        print(f'Could not match any of the results on YouTube for "{display_name}". Skipping')
         raise LookupError("Could not match any of the results on YouTube for")
     else:
         print(" " * (len(display_name) + 25), end="\r")


### PR DESCRIPTION
# Small QoL change to easily see failed tracks
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a really small change that simply shows the `display_name` of the track that has failed the lookup, so it can be easily referenced.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
At the moment, when a track fails to be found on YouTube you are only presented with the phrase:

> Could not match any of the results on YouTube. Skipping

This change is a really small change that simply shows the `display_name` of the track that has failed the lookup, so it can be easily referenced. E.g.

> Could not match any of the results on YouTube for "Karl Jenkins, Carmine Lauri, David Alberman, London Symphony Orchestra - Palladio: 1. Allegretto (arr. for Strings Orchestra)". Skipping

This makes it really easy to find what has been skipped, as at the moment its really difficult to manually cross reference with the Spotify playlist to find what has been skipped, especially due to threading playing with the execution order.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Arch: arm64
- Env: macOS 12.1
- Python: 3.10.1

Code is using the same `print(f'my text')` code format as the other string variable interpolation to remain consistent, nothing looks out of place.

Tested on an example run with the following output:

```sh
➜  ./lspotdl.sh https://open.spotify.com/playlist/60VVAgDtr5bEoJy2fpoIa2
Fetching Playlist...
Found YouTube URL for "Sir Sly - Welcomes The Pressure" : https://www.youtube.com/watch?v=FFNPMzniPZ0
Found YouTube URL for "Silver Maple - September Skies" : https://www.youtube.com/watch?v=FzNIiE_p3es
Found YouTube URL for "SHAED - Six In The Morning" : https://www.youtube.com/watch?v=ZJXZHrwx0oA
Found YouTube URL for "Sia - Elastic Heart" : https://www.youtube.com/watch?v=g40o6EpiEtM
Found YouTube URL for "Sigur Rós - Hoppípolla" : https://www.youtube.com/watch?v=L2eURgrgtiY
Found YouTube URL for "Sheryl Crow - All I Wanna Do" : https://www.youtube.com/watch?v=RiOtjXUpflY
Could not match any of the results on YouTube for "Karl Jenkins, Carmine Lauri, David Alberman, London Symphony Orchestra - Palladio: 1. Allegretto (arr. for Strings Orchestra)". Skipping
Found YouTube URL for "Shakira, Wyclef Jean - Hips Don't Lie (feat. Wyclef Jean)" : https://www.youtube.com/watch?v=o2H75PQdMHM
Found YouTube URL for "Skee-Lo - I Wish - Radio Edit" : https://www.youtube.com/watch?v=i8JfCSTqQYs

<etc.>
```

I checked the tests to find relevant impacted areas and couldn't find anything, so manual testing it is.

## Screenshots (if appropriate)
None, code example above of CLI output.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
