### PR TITLE
Add encoding parameter to youtubedl

### DIFF
--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -190,6 +190,7 @@ class DownloadManager:
                     "outtmpl": f"{temp_folder}/%(id)s.%(ext)s",
                     "quiet": True,
                     "no_warnings": True,
+                    "encoding": "UTF-8",
                     "logger": YTDLLogger(),
                     "progress_hooks": [display_progress_tracker.ytdl_progress_hook]
                     if display_progress_tracker


### PR DESCRIPTION
# Title
Pass encoding parameter to youtubedl

## Description
The current version of YoutubeDL seems to require the encoding parameter. Perhaps it would be nice if you could pass encoding as a parameter to spotdl, but for now this is a quick fix to get spotdl to run again.

## Motivation and Context
With the current version of YoutubeDL, SpotDL is broken

## How Has This Been Tested?
Ran it from a docker container using the Dockerfile in the repo; works.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
