### PR TITLE
improve youtube search

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,8 +65,9 @@ body:
 - type: textarea
   attributes:
     label: Steps to reproduce
-    description: Please ensure to include Spotify links and the actual command 
-    you used.
+    description: |
+      Please ensure to include Spotify links and the actual command 
+      you used.
     placeholder: |
       1.
       2.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
 
 - type: dropdown
   attributes:
-    label: System OS
+    label: System Operating System (OS)
     description: OS not listed here? Please let us know below
     options:
       - Windows
@@ -31,6 +31,7 @@ body:
       - 3.7 (CPython)
       - 3.8 (CPython)
       - 3.9 (CPython)
+      - 3.10 (CPython)
   validations:
     required: true
 
@@ -41,6 +42,8 @@ body:
     options:
       - pip / PyPi
       - GitHub
+      - Termux Installation Script (spotDL provided)
+      - Arch User Repository (Unofficial)
   validations:
     required: true
 
@@ -50,7 +53,7 @@ body:
     description: |
       Supply version if installed from pip, found via `pip show spotdl`
       or supply commit hash if installed from GitHub
-    placeholder: v4.x.x or hash-value
+    placeholder: v3.x.x or hash-value
   validations:
     required: true
 
@@ -62,6 +65,8 @@ body:
 - type: textarea
   attributes:
     label: Steps to reproduce
+    description: Please ensure to include Spotify links and the actual command 
+    you used.
     placeholder: |
       1.
       2.

--- a/spotdl/providers/yt_provider.py
+++ b/spotdl/providers/yt_provider.py
@@ -28,7 +28,7 @@ def search_and_get_best_match(
 
     `str` `song_album_name` : name of song's album
 
-    `int` `song_duration` : duration of the song
+    `int` `song_duration` : duration of the song, in seconds
 
     `str` `isrc` :  code for identifying sound recordings and music video recordings
 
@@ -79,7 +79,6 @@ def _order_yt_results(
     song_artists: List[str],
     song_duration: int,
 ) -> dict:
-
     # Assign an overall avg match value to each result
     links_with_match_value = {}
 
@@ -114,9 +113,11 @@ def _order_yt_results(
         for artist in song_artists:
             # ! something like _match_percentage('rionos', 'aiobahn, rionos Motivation
             # ! (remix)' would return 100, so we're absolutely corrent in matching
-            # ! artists to song name.
+            # ! artists to song name. Also allow for matching artist to video author.
             if _match_percentage(
                 str(unidecode(artist.lower())), str(unidecode(result.title).lower()), 85
+            ) or _match_percentage(
+                str(unidecode(artist.lower())), str(unidecode(result.author).lower()), 85
             ):
                 artist_match_number += 1
 
@@ -126,10 +127,19 @@ def _order_yt_results(
             continue
 
         artist_match = (artist_match_number / len(song_artists)) * 100
-        song_title = _create_song_title(song_name, song_artists).lower()
+
+        song_title = _create_song_title(song_name, song_artists)
         name_match = round(
-            _match_percentage(
-                str(unidecode(result.title.lower())), str(unidecode(song_title)), 60
+            max(
+                # case where artist is included in title
+                _match_percentage(
+                    str(unidecode(song_title.lower())), str(unidecode(result.title.lower())), 60
+                ),
+
+                # case where artist is author and video title is only the track name
+                _match_percentage(
+                    str(unidecode(song_name.lower())), str(unidecode(result.title.lower())), 60
+                )
             ),
             ndigits=3,
         )
@@ -146,7 +156,7 @@ def _order_yt_results(
         # ! seconds, we need to amplify the delta if it is to have any meaningful impact
         # ! wen we calculate the avg match value
         delta = result.length - song_duration  # ! check this
-        non_match_value = (delta**2) / song_duration * 100
+        non_match_value = (delta ** 2) / song_duration * 100
 
         time_match = 100 - non_match_value
 


### PR DESCRIPTION
improve youtube search for case where video author is artist, video title is just song name-- before, this would usually not be marked as a match.

## Related Issue
[[<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->](https://github.com/spotDL/spotify-downloader/issues/1500)](https://github.com/spotDL/spotify-downloader/issues/1500)

## Motivation and Context
search results return 0 in scenario where desired video is configured such that the author is the artist and the title is just the song name-- this is a case for many valid, high-quality tracks on youtube.

## How Has This Been Tested?
Before, was not returning any videos when the desired youtube video was set up like this. After the fix, the video was found.


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ X] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ X] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [ X] All new and existing tests passed
