### PR TITLE
Managed exception artist and album metadata

### DIFF
--- a/spotdl/providers/metadata_provider.py
+++ b/spotdl/providers/metadata_provider.py
@@ -15,10 +15,16 @@ def from_url(spotify_url: str):
             "Couldn't get metadata, check if you have passed correct track id"
         )
 
-    primary_artist_id = raw_track_meta["artists"][0]["id"]
-    raw_artist_meta = spotify_client.artist(primary_artist_id)
+    try:
+        primary_artist_id = raw_track_meta["artists"][0]["id"]
+        raw_artist_meta = spotify_client.artist(primary_artist_id)
+    except:
+        raw_artist_meta = ""
 
-    albumId = raw_track_meta["album"]["id"]
-    raw_album_meta = spotify_client.album(albumId)
+    try:
+        albumId = raw_track_meta["album"]["id"]
+        raw_album_meta = spotify_client.album(albumId)
+    except:
+        raw_album_meta = ""
 
     return raw_track_meta, raw_artist_meta, raw_album_meta


### PR DESCRIPTION
Managed exception artist and album metadata: if spotify api replys with a 404 code, spotdl still has to download the song, without metadata (it hasn't to raise an exception).
