### PR TITLE
Exclude termux and tests folder in package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,12 @@ dev =
 console_scripts=
     spotdl = spotdl:console_entry_point
 
+
+[options.packages.find]
+exclude =
+    termux*
+    tests*
+
 [mypy]
 ignore_missing_imports = True
 


### PR DESCRIPTION
## Description
I'm one of maintainers of https://aur.archlinux.org/packages/python-spotdl package and the problem we faced was that `python-spotdl` package was installing tests folder in `/usr/lib/python3.10/site-packages/tests/__init__.py` instead of its folder (`/usr/lib/python3.10/site-packages/python-spotdl`).
```
/usr/lib/python3.10/site-packages/tests/__init__.py exists in filesystem (owned by python-spotdl)
/usr/lib/python3.10/site-packages/tests/__pycache__/__init__.cpython-310.opt-1.pyc exists in filesystem (owned by python-spotdl)
/usr/lib/python3.10/site-packages/tests/__pycache__/__init__.cpython-310.pyc exists in filesystem (owned by python-spotdl)
```
The solution Arch official guidelines suggest is to remove `tests` folder manually after packaging (https://wiki.archlinux.org/title/Python_package_guidelines#Test_directory_in_site-package)
So this was added to PKGBUILD:
```
	local site_packages=$(python -c "import site; print(site.getsitepackages()[0])")
	rm -rf "${pkgdir}${site_packages}/tests/"
```

But I guess this is something that should be fixed upstream, so I came up with this PR.

A [suggestion](https://aur.archlinux.org/packages/python-spotdl#comment-865789) was to change `packages = find:` to `packages = spotdl`, but after some searching I reached [this change](https://github.com/spotDL/spotify-downloader/commit/bee7b76924c3b03ac41ec63367539e3cee675620) instead.

## Related Issue
Fixes https://github.com/spotDL/spotify-downloader/issues/1524

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
