### PR TITLE
Update Termux installation script path on docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Refer to our [Installation Guide](https://spotdl.rtfd.io/en/latest/installation/
 - Prebuilt Executable
   - You can download the latest version from from the [Releases Tab](https://github.com/spotDL/spotify-downloader/releases)
 - On Termux
-  - `curl -L https://raw.githubusercontent.com/spotDL/spotify-downloader/master/termux/setup_spotdl.sh | sh`
+  - `curl -L https://raw.githubusercontent.com/spotDL/spotify-downloader/master/scripts/termux.sh | sh`
 - Arch
   - There is an Arch User Repository (AUR) package for [spotDL](https://aur.archlinux.org/packages/python-spotdl/).
 - Docker

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ Refer to our [Installation Guide](https://spotdl.rtfd.io/en/latest/installation/
 - Prebuilt Executable
     - You can download the latest version from from the [Releases Tab](https://github.com/spotDL/spotify-downloader/releases)
 - On Termux
-    - `curl -L https://raw.githubusercontent.com/spotDL/spotify-downloader/master/termux/setup_spotdl.sh | sh`
+    - `curl -L https://raw.githubusercontent.com/spotDL/spotify-downloader/master/scripts/termux.sh | sh`
 - Arch
     - There is an Arch User Repository (AUR) package for [spotDL](https://aur.archlinux.org/packages/python-spotdl/).
 - Docker

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -110,7 +110,7 @@ docker create \
 ### Termux
 
 We have a dedicated Termux installation script
-`curl -L https://raw.githubusercontent.com/spotDL/spotify-downloader/master/termux/setup_spotdl.sh | sh`
+`curl -L https://raw.githubusercontent.com/spotDL/spotify-downloader/master/scripts/termux.sh | sh`
 
 ### Arch User Repository (AUR) package
 


### PR DESCRIPTION
Termux installation script was moved here https://github.com/spotDL/spotify-downloader/commit/10c6b294df1810b7d3cf736808d622474e03bb29 , but the broken path still on readme and docs.