### PR TITLE
Add authorisation token authentication method

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -216,6 +216,7 @@ If you don't want config to load automatically change `load_config` option in co
     "overwrite": "skip",
     "client_id": "5f573c9620494bae87890c0f08a60293",
     "client_secret": "212476d9b0f3472eaa762d90b19b0ba8",
+    "auth_token": null,
     "user_auth": false,
     "search_query": null,
     "filter_results": true,
@@ -263,6 +264,8 @@ Spotify options:
                         The client id to use when logging in to Spotify.
   --client-secret CLIENT_SECRET
                         The client secret to use when logging in to Spotify.
+  --auth-token AUTH_TOKEN
+                        The authorisation token to use directly to log in to Spotify.
   --cache-path CACHE_PATH
                         The path where spotipy cache file will be stored.
   --no-cache            Disable caching (both requests and token).

--- a/spotdl/console/entry_point.py
+++ b/spotdl/console/entry_point.py
@@ -183,6 +183,7 @@ def entry_point():
     SpotifyClient.init(
         client_id=settings["client_id"],
         client_secret=settings["client_secret"],
+        auth_token=settings["auth_token"],
         user_auth=settings["user_auth"],
         cache_path=settings["cache_path"],
         no_cache=settings["no_cache"],

--- a/spotdl/utils/arguments.py
+++ b/spotdl/utils/arguments.py
@@ -217,6 +217,13 @@ def parse_spotify_options(parser: _ArgumentGroup):
         help="The client secret to use when logging in to Spotify.",
     )
 
+    # Add auth token argument
+    parser.add_argument(
+        "--auth-token",
+        default=DEFAULT_CONFIG["auth_token"],
+        help="The authorisation token to use directly to log in to Spotify.",
+    )
+
     # Add cache path argument
     parser.add_argument(
         "--cache-path",

--- a/spotdl/utils/config.py
+++ b/spotdl/utils/config.py
@@ -131,6 +131,7 @@ DEFAULT_CONFIG = {
     "overwrite": "skip",
     "client_id": "5f573c9620494bae87890c0f08a60293",
     "client_secret": "212476d9b0f3472eaa762d90b19b0ba8",
+    "auth_token": None,
     "user_auth": False,
     "search_query": None,
     "filter_results": True,

--- a/spotdl/utils/spotify.py
+++ b/spotdl/utils/spotify.py
@@ -53,6 +53,7 @@ class Singleton(type):
         self,
         client_id: str,
         client_secret: str,
+        auth_token: Optional[str] = None,
         user_auth: bool = False,
         cache_path: Optional[str] = None,
         no_cache: bool = False,
@@ -64,6 +65,7 @@ class Singleton(type):
         ### Arguments
         - client_id: The client ID of the application.
         - client_secret: The client secret of the application.
+        - auth_token: The access token to use.
         - user_auth: Whether or not to use user authentication.
         - cache_path: The path to the cache file.
         - no_cache: Whether or not to use the cache.
@@ -101,12 +103,15 @@ class Singleton(type):
                 client_secret=client_secret,
                 cache_handler=cache_handler,
             )
+        if auth_token is not None:
+            credential_manager = None
 
         self.user_auth = user_auth
         self.no_cache = no_cache
 
         # Create instance
         self._instance = super().__call__(
+            auth=auth_token,
             auth_manager=credential_manager,
             status_forcelist=(429, 500, 502, 503, 504, 404),
         )
@@ -129,6 +134,7 @@ class SpotifyClient(Spotify, metaclass=Singleton):
         Initializes the SpotifyClient.
 
         ### Arguments
+        - auth: The access token to use.
         - auth_manager: The auth manager to use.
         """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ class FakeProcess:
 def new_initialize(
     client_id,
     client_secret,
+    auth_token=None,
     user_auth=False,
     cache_path=None,
     no_cache=True,
@@ -51,6 +52,7 @@ def new_initialize(
         return ORIGINAL_INITIALIZE(
             client_id=client_id,
             client_secret=client_secret,
+            auth_token=auth_token,
             user_auth=user_auth,
             cache_path=cache_path,
             no_cache=True,


### PR DESCRIPTION
# Title
Add authorisation token authentication method

## Description
Allows a static authorisation token to be used to authenticate with the Spotify API, as implemented by spotipy. The token can be passed through the CLI or in the configuration file.

## Related Issue
https://github.com/spotDL/spotify-downloader/issues/1579

## Motivation and Context
When calling spotDL from another program, an authorisation token may already be available, and preferable to the other available authentication methods.

## How Has This Been Tested?
I successfully downloaded a private playlist, providing an authorisation token as the only authentication method.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
