### PR TITLE
Remove exception if lyrics not found

### DIFF
--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -299,7 +299,7 @@ class Downloader:
 
         raise LookupError(f"No results found for song: {song.display_name}")
 
-    def search_lyrics(self, song: Song) -> str:
+    def search_lyrics(self, song: Song) -> Optional[str]:
         """
         Search for lyrics using all available providers.
 
@@ -307,7 +307,7 @@ class Downloader:
         - song: The song to search for.
 
         ### Returns
-        - lyrics if successful.
+        - lyrics if successful else None.
         """
 
         for lyrics_provider in self.lyrics_providers:
@@ -323,7 +323,8 @@ class Downloader:
                 f"for {song.display_name}"
             )
 
-        raise LookupError(f"No lyrics found for song: {song.display_name}")
+        self.progress_handler.log(f"No lyrics found for song: {song.display_name}")
+        return None
 
     def search_and_download(self, song: Song) -> Tuple[Song, Optional[Path]]:
         """


### PR DESCRIPTION
# Title
Pull request to remove unnecessary exception if lyrics cannot be found

## Description
The lyrics are declared as Optional on the Song class so if lyrics cannot be found the rest of the meta data can still be loaded successfully.

## Related Issue
https://github.com/spotDL/spotify-downloader/issues/1619

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
I commented out the for loop to find lyrics (as I could not really find a case where this bug could be seen otherwise) simulating no lyrics could be found. With these changes, a log message appears but the meta data is still applied successfully.

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/48325593/194635840-f5568342-b888-4c8e-aea8-7d92fa550b68.png)


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
