### PR TITLE
Improve docker container rebuild speed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,16 @@ RUN apk add --no-cache \
 # Install poetry and update pip/wheel
 RUN pip install --upgrade pip poetry wheel
 
+# Copy requirements files
+COPY poetry.lock pyproject.toml /
+
+# Install spotdl requirements
+RUN poetry install
+
 # Add source code files to WORKDIR
 ADD . .
 
-# Install requirements
+# Install spotdl itself
 RUN poetry install
 
 # Create music directory


### PR DESCRIPTION
# Title
This pull request improve docker container improve process for development.

## Description
Before:

Every change in codebase triggered poetry to install all requirements again since `ADD . .` and docker cache layer break.


After

New approach it to do installation in two steps
1. Copy dependecy locak files and do poetry isntall to install dependecies. Now only changes in `poetry.lock` or `pyproject.toml` 
will trigger poetry to install these dependecies again. In all other cases docker will use cached layer

2. Install package itself with `poetry install`


## Related Issue
This fix the following issue
#1622 

## Motivation and Context
It improve speed for docker container rebuild

## How Has This Been Tested?
Tested locally with the following command

1. ```docker build -t spotdl .```
2.  Change any files except  poetry.lock pyproject.toml
3. Docker should use cached layer for dependencies installation

## Screenshots (if appropriate)
Before the change

![image](https://user-images.githubusercontent.com/899242/194715298-9fb66ad3-4822-4d53-b425-9ff10760789d.png)


After the change

![image](https://user-images.githubusercontent.com/899242/194715167-adb6d275-d0d4-45ba-9629-cf6c4d2ac5c9.png)


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
