### PR TITLE
Fixed spotdl not downlading lyrics when downloading songs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Download your Spotify playlists and songs along with album art and metadata
 
 Please note that v4 is still being worked on, is **not yet fully stable** and unreleased.
 
-To install v4's latest release candidate run `pip install -U --force spotdl==4.0.0rc4`
+To install v4's latest release candidate run `pip install -U --force spotdl==4.0.0rc5`
 > This is correct, the below commands will not install v4.
 
 To install v3 or downgrade to it, run `pip install -U --force spotdl==3.9.6`

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -349,7 +349,7 @@ class Downloader:
 
         # Find song lyrics and add them to the song object
         lyrics = self.search_lyrics(song)
-        if song.lyrics is None:
+        if lyrics is None:
             self.progress_handler.debug(
                 f"No lyrics found for {song.display_name}, "
                 "lyrics providers: "
@@ -357,7 +357,6 @@ class Downloader:
             )
         else:
             song.lyrics = lyrics
-            self.progress_handler.log(f"No lyrics found for song: {song.display_name}")
 
         # Create the output file path
         output_file = create_file_name(song, self.output, self.output_format)


### PR DESCRIPTION
# Title
Fixed spotdl not downlading lyrics when downloading songs

## Description
When spotdl downloads songs, it doesn't save lyrics as ID3 metadata. 
This is because the wrong variable is checked.

Also, the log message _No Lyrics found_ in line 359 is wrong, it should be _Lyrics found_. But since in my opinion an error message indicating that something worked is unnecessary, I removed it completely.
It might be interesting as an Debug/Info, but i don't know which to use and how. 


## Related Issue
None

## How Has This Been Tested?
Using _spotdl download_  for a single song and an album

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
