### PR TITLE
Select highest resolution album cover image

### DIFF
--- a/spotdl/search/song_object.py
+++ b/spotdl/search/song_object.py
@@ -144,7 +144,11 @@ class SongObject:
         images = self._raw_track_meta["album"]["images"]
 
         if len(images) > 0:
-            return images[0]["url"]
+            # Sort images by highest resolution
+            sorted_images = sorted(
+                images, key=lambda i: i["height"] * i["width"], reverse=True
+            )
+            return sorted_images[0]["url"]
 
         return None
 


### PR DESCRIPTION
# Select highest resolution album cover image

## Description
`album_cover_url` now sorts the list of returned thumbnails by resolution and returns the highest-resolution image's URL.

## Related Issue
Fixes #1631

## How Has This Been Tested?
`$ spotdl mozart` now embeds the highest-resolution image available (640x640), confirmed using `ffprobe`:

```
$ ffprobe Wolfgang\ Amadeus\ Mozart,\ Daniel\ Barenboim,\ Berliner\ Philharmoniker\ -\ Mozart\ -\ \ Piano\ Concerto\ No.\ 20\ in\ D\ Minor,\ K.\ 466\ -\ \ I.\ Allegro.mp3
// ... 
  Stream #0:1: Video: mjpeg (Baseline), yuvj444p(pc, bt470bg/unknown/unknown), 640x640 [SAR 300:300 DAR 1:1], 90k tbr, 90k tbn (attached pic)
    Metadata:
      title           : Cover
      comment         : Cover (front)
```

## Screenshots (if appropriate)

(excluding because of US copyright laws)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document<sup>1</sup>
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

*** 

I'm a first-time Hacktoberfest contributor and hope this PR helps. Thanks for your consideration.

<sup>1</sup> Assuming this is [CODE OF CONDUCT](/docs/CODE_OF_CONDUCT.md)?