### PR TITLE
Select highest resolution album cover image (v4)

### DIFF
--- a/spotdl/types/song.py
+++ b/spotdl/types/song.py
@@ -104,7 +104,9 @@ class Song:
             explicit=raw_track_meta["explicit"],
             publisher=raw_album_meta["label"],
             url=raw_track_meta["external_urls"]["spotify"],
-            cover_url=raw_album_meta["images"][0]["url"]
+            cover_url=max(
+                raw_album_meta["images"], key=lambda i: i["width"] * i["height"]
+            )["url"]
             if raw_album_meta["images"]
             else None,
         )


### PR DESCRIPTION
# Select highest resolution album cover image

## Description
`Song.from_url` now selects the highest-resolution image's URL.

## Related Issue
Fixes #1631

## How Has This Been Tested?
`$ spotdl download bach` embeds the highest-resolution image available (640x640), confirmed using `ffprobe`:

```
$ ffprobe Juan\ Luis\ Guerra\ 4.40\ -\ Bachata\ En\ Fukuoka.mp3
// ... 
  Stream #0:1: Video: mjpeg (Baseline), yuvj444p(pc, bt470bg/unknown/unknown), 640x640 [SAR 118:118 DAR 1:1], 90k tbr, 90k tbn (attached pic)
    Metadata:
      title           : Cover
      comment         : Cover (front)
```

## Screenshots (if appropriate)

(excluding because of US copyright laws)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document<sup>1</sup>
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

<sup>1</sup> Assuming this is [CODE OF CONDUCT](/docs/CODE_OF_CONDUCT.md)?