### PR TITLE
Fix metadata when playlist has no images

### DIFF
--- a/spotdl/types/playlist.py
+++ b/spotdl/types/playlist.py
@@ -113,10 +113,10 @@ class Playlist(SongList):
             "description": playlist["description"],
             "author_url": playlist["external_urls"]["spotify"],
             "author_name": playlist["owner"]["display_name"],
-            "cover_url": max(
+            "cover_url": (max(
                 playlist["images"],
                 key=lambda i: 0
                 if i["width"] is None or i["height"] is None
                 else i["width"] * i["height"],
-            )["url"],
+            )["url"] if (len(playlist["images"]) > 0) else ""),
         }


### PR DESCRIPTION
# Title

Some playlists do not provide images which causes the meta data download to raise an error. This pull request prevents the error when no images are found.

## Description
After Downloading the meta data the `cover_url` is set to the largest of its images. When the list of images is empty, this will be skipped and the `cover_url` is set to an empty string.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/spotDL/spotify-downloader/issues/1684

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This enables me to download this playlist: https://open.spotify.com/playlist/7GJBK6ML8jukaCssoZZLwm

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the fix manually by running: `spotdl download https://open.spotify.com/playlist/7GJBK6ML8jukaCssoZZLwm`

I wanted to add a unit test as well but I would have to provide a link to a playlist that would never get an image. This is something that I would not be able to guarantee, so I am not sure if such a unit test should even be part of the code base.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ x ] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ x ] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [ x ] All new and existing tests passed
