### PR TITLE
escape / don't parse square brackets in song names

### DIFF
--- a/spotdl/download/progress_handler.py
+++ b/spotdl/download/progress_handler.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Optional
 from rich import get_console
 from rich.console import JustifyMethod, OverflowMethod
 from rich.highlighter import Highlighter
+from rich.markup import escape
 from rich.progress import (
     BarColumn,
     Progress,
@@ -275,7 +276,7 @@ class SongTracker:
 
         if not self.parent.simple_tui:
             self.task_id = self.parent.rich_progress_bar.add_task(
-                description=self.song_name,
+                description=escape(self.song_name),
                 message="Download Started",
                 total=100,
                 completed=self.progress,
@@ -303,7 +304,7 @@ class SongTracker:
             self.parent.rich_progress_bar.start_task(self.task_id)
             self.parent.rich_progress_bar.update(
                 self.task_id,
-                description=self.song_name,
+                description=escape(self.song_name),
                 message=message,
                 completed=self.progress,
             )

--- a/spotdl/utils/logging.py
+++ b/spotdl/utils/logging.py
@@ -7,6 +7,7 @@ import logging
 from rich import get_console
 from rich.console import ConsoleRenderable
 from rich.logging import RichHandler
+from rich.markup import escape
 from rich.text import Text
 from rich.theme import Theme
 from rich.traceback import install
@@ -94,7 +95,7 @@ class SpotdlFormatter(logging.Formatter):
         Format a log record.
         """
 
-        result = super().format(record)
+        result = escape(super().format(record))
 
         msg = result
         if record.levelno == DEBUG:

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -1,0 +1,25 @@
+from logging import LogRecord
+
+import pytest
+
+from spotdl.utils.logging import DEBUG, NOTSET, SpotdlFormatter
+
+
+def test_spotdl_formatter_format():
+    # cf. https://rich.readthedocs.io/en/stable/markup.html#escaping
+    formatter = SpotdlFormatter()
+
+    input_output_map = {
+        ("[as it is, infinite]", DEBUG): "[blue]\\[as it is, infinite]",
+        ("[effluvium]", NOTSET): "\\[effluvium]",
+        ("DRIP", DEBUG): "[blue]DRIP",
+        ("FOREIGN TONGUES", NOTSET): "FOREIGN TONGUES",
+    }
+
+    for (msg, level), escaped_msg in input_output_map.items():
+        assert (
+            formatter.format(
+                LogRecord("spotdl", level, "", 0, msg, None, None, None, None)
+            )
+            == escaped_msg
+        )


### PR DESCRIPTION
# escape / don't parse square brackets in song names
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Escape log records in `SpotdlFormatter.format` in `logging.py`
	- While this could be done in each log call individually, this is sufficient since console markup does not seem to be used anywhere else.
- Escape song names before passing them as progress bar descriptions

## Related Issue
#1738 

## Motivation and Context
Previously, progress bars and log messages would “swallow” parts of song names that happened to include square brackets, so `Crywolf - [when you inhale, i fill your lungs]` would become  `Crywolf - `, because `rich` would try to read these as _console markup_ (like `[green]`, for example).

## How Has This Been Tested?
- GitHub Codespaces
- tested before/after with this album: [widow [OBLIVIØN Pt. 1]](https://open.spotify.com/album/3xad1D7RkpRz7G6xNjuP44)
- Writing a test for the progress bar descriptions seems like an unreasonably hard task.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document (dead link)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
