### PR TITLE
Fix for sync functionality when using 'restrict' option

### DIFF
--- a/spotdl/console/save.py
+++ b/spotdl/console/save.py
@@ -82,6 +82,7 @@ def save(
             m3u_file,
             downloader.settings["output"],
             downloader.settings["format"],
+            downloader.settings["restrict"],
             False,
         )
 

--- a/spotdl/console/sync.py
+++ b/spotdl/console/sync.py
@@ -74,6 +74,7 @@ def sync(
                 m3u_file,
                 downloader.settings["output"],
                 downloader.settings["format"],
+                downloader.settings["restrict"],
                 False,
             )
 
@@ -129,6 +130,7 @@ def sync(
                 m3u_file,
                 downloader.settings["output"],
                 downloader.settings["format"],
+                downloader.settings["restrict"],
                 False,
             )
 

--- a/spotdl/console/sync.py
+++ b/spotdl/console/sync.py
@@ -99,6 +99,7 @@ def sync(
                 Song.from_dict(entry),
                 downloader.settings["output"],
                 downloader.settings["format"],
+                downloader.settings["restrict"]
             )
             old_files.append((file_name, entry["url"]))
 

--- a/spotdl/console/sync.py
+++ b/spotdl/console/sync.py
@@ -100,7 +100,7 @@ def sync(
                 Song.from_dict(entry),
                 downloader.settings["output"],
                 downloader.settings["format"],
-                downloader.settings["restrict"]
+                downloader.settings["restrict"],
             )
             old_files.append((file_name, entry["url"]))
 

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -283,6 +283,7 @@ class Downloader:
                 self.settings["m3u"],
                 self.settings["output"],
                 self.settings["format"],
+                self.settings["restrict"],
                 False,
             )
 

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -31,7 +31,7 @@ from spotdl.utils.config import (
     get_temp_path,
 )
 from spotdl.utils.ffmpeg import FFmpegError, convert, get_ffmpeg_path
-from spotdl.utils.formatter import create_file_name, restrict_filename
+from spotdl.utils.formatter import create_file_name
 from spotdl.utils.m3u import gen_m3u_files
 from spotdl.utils.metadata import MetadataError, embed_metadata
 from spotdl.utils.search import gather_known_songs, reinit_song, songs_from_albums
@@ -381,12 +381,18 @@ class Downloader:
         try:
             # Create the output file path
             output_file = create_file_name(
-                song, self.settings["output"], self.settings["format"], self.settings["restrict"]
+                song,
+                self.settings["output"],
+                self.settings["format"],
+                self.settings["restrict"],
             )
         except Exception:
             song = reinit_song(song, self.settings["playlist_numbering"])
             output_file = create_file_name(
-                song, self.settings["output"], self.settings["format"], self.settings["restrict"]
+                song,
+                self.settings["output"],
+                self.settings["format"],
+                self.settings["restrict"],
             )
 
             reinitialized = True

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -380,12 +380,12 @@ class Downloader:
         try:
             # Create the output file path
             output_file = create_file_name(
-                song, self.settings["output"], self.settings["format"]
+                song, self.settings["output"], self.settings["format"], self.settings["restrict"]
             )
         except Exception:
             song = reinit_song(song, self.settings["playlist_numbering"])
             output_file = create_file_name(
-                song, self.settings["output"], self.settings["format"]
+                song, self.settings["output"], self.settings["format"], self.settings["restrict"]
             )
 
             reinitialized = True
@@ -395,10 +395,6 @@ class Downloader:
 
         # Create the temp folder path
         temp_folder = get_temp_path()
-
-        # Restrict the filename if needed
-        if self.settings["restrict"] is True:
-            output_file = restrict_filename(output_file)
 
         # Check if there is an already existing song file, with the same spotify URL in its
         # metadata, but saved under a different name. If so, save its path.

--- a/spotdl/utils/formatter.py
+++ b/spotdl/utils/formatter.py
@@ -293,7 +293,8 @@ def create_file_name(
     song: Song,
     template: str,
     file_extension: str,
-    short: bool = False,
+    restrict: bool = False,
+    short: bool = False
 ) -> Path:
     """
     Create the file name for the song, by replacing template variables with the actual values.
@@ -302,6 +303,7 @@ def create_file_name(
     - song: the song object
     - template: the template string
     - file_extension: the file extension to use
+    - restrict: whether to sanitize the filename
     - short: whether to use the short version of the template
 
     ### Returns
@@ -364,15 +366,21 @@ def create_file_name(
                 song=song,
                 template="/{artist} - {title}.{output-ext}",
                 file_extension=file_extension,
-                short=short,
+                restrict=restrict,
+                short=short
             )
 
         return create_file_name(
             song,
             template,
             file_extension,
-            short=True,
+            restrict=restrict,
+            short=True
         )
+
+    # Restrict the filename if needed
+    if restrict:
+        return restrict_filename(file)
 
     return file
 

--- a/spotdl/utils/formatter.py
+++ b/spotdl/utils/formatter.py
@@ -294,7 +294,7 @@ def create_file_name(
     template: str,
     file_extension: str,
     restrict: bool = False,
-    short: bool = False
+    short: bool = False,
 ) -> Path:
     """
     Create the file name for the song, by replacing template variables with the actual values.
@@ -367,15 +367,11 @@ def create_file_name(
                 template="/{artist} - {title}.{output-ext}",
                 file_extension=file_extension,
                 restrict=restrict,
-                short=short
+                short=short,
             )
 
         return create_file_name(
-            song,
-            template,
-            file_extension,
-            restrict=restrict,
-            short=True
+            song, template, file_extension, restrict=restrict, short=True
         )
 
     # Restrict the filename if needed

--- a/spotdl/utils/m3u.py
+++ b/spotdl/utils/m3u.py
@@ -15,7 +15,7 @@ __all__ = [
 
 
 def create_m3u_content(
-    song_list: List[Song], template: str, file_extension: str, short: bool = False
+    song_list: List[Song], template: str, file_extension: str, restrict: bool = False, short: bool = False
 ) -> str:
     """
     Create m3u content and return it as a string.
@@ -32,7 +32,7 @@ def create_m3u_content(
 
     text = ""
     for song in song_list:
-        text += str(create_file_name(song, template, file_extension, short=short)) + "\n"
+        text += str(create_file_name(song, template, file_extension, restrict, short)) + "\n"
 
     return text
 
@@ -42,6 +42,7 @@ def gen_m3u_files(
     file_name: Optional[str],
     template: str,
     file_extension: str,
+    restrict: bool = False,
     short: bool = False,
 ):
     """
@@ -95,6 +96,7 @@ def gen_m3u_files(
                 song_list.songs,
                 template,
                 file_extension,
+                restrict,
                 short,
             )
     elif "{list[" in file_name and "]}" in file_name:
@@ -104,6 +106,7 @@ def gen_m3u_files(
             songs,
             template,
             file_extension,
+            restrict,
             short,
         )
     else:
@@ -113,6 +116,7 @@ def gen_m3u_files(
             songs,
             template,
             file_extension,
+            restrict,
             short,
         )
 
@@ -122,6 +126,7 @@ def create_m3u_file(
     song_list: List[Song],
     template: str,
     file_extension: str,
+    restrict: bool = False,
     short: bool = False,
 ) -> str:
     """
@@ -138,7 +143,7 @@ def create_m3u_file(
     - the m3u content as a string
     """
 
-    m3u_content = create_m3u_content(song_list, template, file_extension, short)
+    m3u_content = create_m3u_content(song_list, template, file_extension, restrict, short)
 
     with open(file_name, "w", encoding="utf-8") as m3u_file:
         m3u_file.write(m3u_content)

--- a/spotdl/utils/m3u.py
+++ b/spotdl/utils/m3u.py
@@ -15,7 +15,11 @@ __all__ = [
 
 
 def create_m3u_content(
-    song_list: List[Song], template: str, file_extension: str, restrict: bool = False, short: bool = False
+    song_list: List[Song],
+    template: str,
+    file_extension: str,
+    restrict: bool = False,
+    short: bool = False,
 ) -> str:
     """
     Create m3u content and return it as a string.
@@ -24,6 +28,7 @@ def create_m3u_content(
     - song_list: the list of songs
     - template: the template to use
     - file_extension: the file extension to use
+    - restrict: whether to sanitize the filename
     - short: whether to use the short version of the template
 
     ### Returns
@@ -32,7 +37,10 @@ def create_m3u_content(
 
     text = ""
     for song in song_list:
-        text += str(create_file_name(song, template, file_extension, restrict, short)) + "\n"
+        text += (
+            str(create_file_name(song, template, file_extension, restrict, short))
+            + "\n"
+        )
 
     return text
 
@@ -54,6 +62,7 @@ def gen_m3u_files(
     - song_list: the list of songs
     - template: the output file template to use
     - file_extension: the file extension to use
+    - restrict: whether to sanitize the filename
     - short: whether to use the short version of the template
     """
 
@@ -137,13 +146,16 @@ def create_m3u_file(
     - song_list: the list of songs
     - template: the template to use
     - file_extension: the file extension to use
+    - restrict: whether to sanitize the filename
     - short: whether to use the short version of the template
 
     ### Returns
     - the m3u content as a string
     """
 
-    m3u_content = create_m3u_content(song_list, template, file_extension, restrict, short)
+    m3u_content = create_m3u_content(
+        song_list, template, file_extension, restrict, short
+    )
 
     with open(file_name, "w", encoding="utf-8") as m3u_file:
         m3u_file.write(m3u_content)

--- a/spotdl/utils/m3u.py
+++ b/spotdl/utils/m3u.py
@@ -32,7 +32,7 @@ def create_m3u_content(
 
     text = ""
     for song in song_list:
-        text += str(create_file_name(song, template, file_extension, short)) + "\n"
+        text += str(create_file_name(song, template, file_extension, short=short)) + "\n"
 
     return text
 

--- a/tests/utils/test_formatter.py
+++ b/tests/utils/test_formatter.py
@@ -92,6 +92,14 @@ def test_create_file_name():
         "GB2LD2110301/Ropes - Dirty Palm....mp3"
     )
 
+    assert create_file_name(song, "{title} - {artist}", "mp3", restrict=True, short=False) == Path(
+        "Ropes-Dirty_Palm.mp3"
+    )
+
+    assert create_file_name(song, "{title} - {artist}", "mp3", restrict=True, short=True) == Path(
+        "Ropes-Dirty_Palm.mp3"
+    )
+
     assert create_file_name(
         song,
         "{list-position}/{list-length} {title} - {artist}",


### PR DESCRIPTION
# Title
Fix bug with the sync function when using with `--restrict` command line option.

## Description
In the current version (4.1.2) songs are not deleted when using the sync function in combination with `--restrict` command line option.
I added a `restrict` parameter to the `create_file_name` function so that filenames are sanitized whenever `--restrict` command line option is used.

Discussion about the bug: https://discord.com/channels/771628785447337985/1082223170418921542

## Related Issue
https://github.com/spotDL/spotify-downloader/issues/1764

## Motivation and Context
Bugfix

## How Has This Been Tested?
- Tested with same case as related issue #1764 
- Bug might affect M3U code too because `create_file_name` is used there too but I'm not familiar with that functionality.

## Types of Changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [X] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed
