### PR TITLE
Documentation - Update usage.md

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -148,13 +148,13 @@ This will download new songs and remove the ones that are no longer present in t
     To sync the songs run
 
     ```bash
-    spotdl sync [fileName]
+    spotdl sync [query]
     ```
 
     example:
 
     ```bash
-    spotdl sync "the-weeknd.sync.spotdl"
+    spotdl sync https://open.spotify.com/playlist/37i9dQZF1E8UXBoz02kGID
     ```
 
 ## Saving


### PR DESCRIPTION
# Title
Syncing documentation seems to be outdated?

## Description
To sync, you need to first create a save file, but then later to re-sync you're supposed to use the query as a parameter instead of the save file.

When I try to use the save file as a parameter with sync I get this error message: "ValueError: Cannot create a sync file with a .spotdl file in the query."