### PR TITLE
Fix URL command usage in ReadME.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ For a list of all **options** use ```spotdl -h```
 
 - `url`: Get direct download link for each song from the query.
     - Usage:
-        `spotdl web [query]`
+        `spotdl url [query]`
 
 - `sync`: Updates directories. Compares the directory with the current state of the playlist. Newly added songs will be downloaded and removed songs will be deleted. No other songs will be downloaded and no other files will be deleted.
 


### PR DESCRIPTION
# Title
Readme's URL command usage fix.

*skipping rest of the checklist here, since a minor change it is, and hopefully you won't mind.*
