### PR TITLE
v4.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Refer to our [Installation Guide](https://spotdl.rtfd.io/en/latest/installation/
 
 ### Python (Recommended Method)
   - _spotDL_ can be installed by running `pip install spotdl`.
+  - To update spotDL run `pip install --upgrade spotdl`
+
   > On some systems you might have to change `pip` to `pip3`.
 
 <details>

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ For a list of all **options** use ```spotdl -h```
 
 - `url`: Get direct download link for each song from the query.
     - Usage:
-        `spotdl web [query]`
+        `spotdl url [query]`
 
 - `sync`: Updates directories. Compares the directory with the current state of the playlist. Newly added songs will be downloaded and removed songs will be deleted. No other songs will be downloaded and no other files will be deleted.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,11 +135,11 @@ spotDL uses YouTube as a source for music downloads. This method is used to avoi
 
 spotDL downloads music from YouTube and is designed to always download the highest possible bitrate; which is 128 kbps for regular users and 256 kbps for YouTube Music premium users.
 
-Check the [Audio Formats](docs/USAGE.md#audio-formats-and-quality) page for more info.
+Check the [Audio Formats](USAGE#audio-formats-and-quality) page for more info.
 
 ## Contributing
 
-Interested in contributing? Check out our [CONTRIBUTING.md](docs/CONTRIBUTING.md) to find
+Interested in contributing? Check out our [CONTRIBUTING.md](CONTRIBUTING) to find
 resources around contributing along with a guide on how to set up a development environment.
 
 ## Donate

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ Refer to our [Installation Guide](https://spotdl.rtfd.io/en/latest/installation/
 
 ### Python (Recommended Method)
   - _spotDL_ can be installed by running `pip install spotdl`.
+  - To update spotDL run `pip install --upgrade spotdl`
   > On some systems you might have to change `pip` to `pip3`.
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,7 @@ General usage:
 ```sh
 spotdl [operation] [options] QUERY
 ```
+When downloading songs, the song's Spotify Popularity variable [(described here)](https://developer.spotify.com/documentation/web-api/reference/get-track) is stored in metadata as a comment, so you can sort your downloaded songs by popularity.
 
 There are different **operations** spotDL can perform. The *default* is `download`, which simply downloads the songs from YouTube and embeds metadata.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "spotdl"
-version = "4.1.10"
+version = "4.1.11"
 description = "Download your Spotify playlists and songs along with album art and metadata"
 license = "MIT"
 authors = ["spotDL Team <spotdladmins@googlegroups.com>"]

--- a/spotdl/_version.py
+++ b/spotdl/_version.py
@@ -2,4 +2,4 @@
 Version module for spotdl.
 """
 
-__version__ = "4.1.10"
+__version__ = "4.1.11"

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -604,7 +604,7 @@ class Downloader:
                 self.settings["bitrate"] in ["auto", "disable", None]
                 and temp_file.suffix == output_file.suffix
             ):
-                shutil.move(temp_file, output_file)
+                shutil.move(str(temp_file), output_file)
                 success = True
                 result = None
             else:

--- a/spotdl/types/song.py
+++ b/spotdl/types/song.py
@@ -51,6 +51,7 @@ class Song:
     copyright_text: Optional[str]
     download_url: Optional[str] = None
     lyrics: Optional[str] = None
+    popularity: Optional[int] = None
     album_id: Optional[str] = None
     list_name: Optional[str] = None
     list_url: Optional[str] = None
@@ -118,6 +119,7 @@ class Song:
             explicit=raw_track_meta["explicit"],
             publisher=raw_album_meta["label"],
             url=raw_track_meta["external_urls"]["spotify"],
+            popularity=raw_track_meta["popularity"],
             cover_url=max(
                 raw_album_meta["images"], key=lambda i: i["width"] * i["height"]
             )["url"]

--- a/spotdl/utils/formatter.py
+++ b/spotdl/utils/formatter.py
@@ -371,7 +371,12 @@ def create_file_name(
     long_title = len(song.name) > (length_limit * 0.50)
 
     path_separator = "/" if "/" in template else "\\"
-    name_template = template.rsplit(path_separator, 1)[1]
+    name_template_parts = template.rsplit(path_separator, 1)
+    name_template = (
+        name_template_parts[1]
+        if len(name_template_parts) == 1
+        else name_template_parts[0]
+    )
 
     if long_artist:
         logger.warning(

--- a/spotdl/utils/metadata.py
+++ b/spotdl/utils/metadata.py
@@ -56,7 +56,6 @@ M4A_TAG_PRESET = {
     "date": "\xa9day",
     "title": "\xa9nam",
     "year": "\xa9day",
-    "originaldate": "purd",
     "comment": "\xa9cmt",
     "group": "\xa9grp",
     "writer": "\xa9wrt",
@@ -80,7 +79,6 @@ MP3_TAG_PRESET = {
     "date": "TDRC",
     "title": "TIT2",
     "year": "TDRC",
-    "originaldate": "TDOR",
     "comment": "COMM::XXX",
     "group": "TIT1",
     "writer": "TEXT",
@@ -163,7 +161,6 @@ def embed_metadata(output_file: Path, song: Song, id3_separator: str = "/"):
     )
     audio_file[tag_preset["title"]] = song.name
     audio_file[tag_preset["date"]] = song.date
-    audio_file[tag_preset["originaldate"]] = song.date
     audio_file[tag_preset["encodedby"]] = song.publisher
 
     # Embed metadata that isn't always present
@@ -469,8 +466,6 @@ def get_file_metadata(path: Path, id3_separator: str = "/") -> Optional[Dict[str
         else:
             if key == "artist":
                 song_meta["artists"] = val
-            if key == "originaldate":
-                song_meta["year"] = int(str(val[0])[:4])
             elif key == "tracknumber":
                 song_meta["track_number"] = int(val[0])
             elif key == "discnumber":

--- a/spotdl/utils/metadata.py
+++ b/spotdl/utils/metadata.py
@@ -209,6 +209,15 @@ def embed_metadata(output_file: Path, song: Song, id3_separator: str = "/"):
         if song.download_url:
             audio_file.add(COMM(encoding=3, text=song.download_url))
 
+        if song.popularity:
+            audio_file.add(
+                COMM(
+                    encoding=3,
+                    lang="eng",
+                    text="Spotify Popularity: " + str(song.popularity),
+                )
+            )
+
     # Embed album art
     audio_file = embed_cover(audio_file, song, encoding)
 

--- a/spotdl/utils/search.py
+++ b/spotdl/utils/search.py
@@ -7,8 +7,8 @@ To use this module you must first initialize the SpotifyClient.
 
 import concurrent.futures
 import json
-import re
 import logging
+import re
 from pathlib import Path
 from typing import Dict, List, Optional
 

--- a/tests/types/test_song.py
+++ b/tests/types/test_song.py
@@ -32,6 +32,7 @@ def test_song_init():
         disc_count=1,
         publisher="test",
         url="test",
+        popularity=1,
     )
 
     assert song.name == "test"
@@ -51,6 +52,7 @@ def test_song_init():
     assert song.cover_url == "test"
     assert song.explicit is True
     assert song.download_url == "test"
+    assert song.popularity == 1
 
 
 def test_song_wrong_init():
@@ -99,6 +101,7 @@ def test_song_from_url():
     )
     assert song.explicit == False
     assert song.download_url == None
+    assert song.popularity == 0
 
 
 @pytest.mark.vcr()
@@ -124,6 +127,7 @@ def test_song_from_search_term():
     assert song.song_id == "4SN9kQlguIcjPtMNQJwD30"
     assert song.explicit == False
     assert song.download_url == None
+    assert song.popularity == 34
 
 
 def test_song_from_data_dump():
@@ -156,7 +160,8 @@ def test_song_from_data_dump():
             "disc_count": 1,
             "copyright_text": "",
             "publisher": "",
-            "url": "https://open.spotify.com/track/1t2qKa8K72IBC8yQlhD9bU"
+            "url": "https://open.spotify.com/track/1t2qKa8K72IBC8yQlhD9bU",
+            "popularity": 0
         }
         """
     )
@@ -180,6 +185,7 @@ def test_song_from_data_dump():
     )
     assert song.explicit == False
     assert song.download_url == None
+    assert song.popularity == 0
 
 
 def test_song_from_data_dump_wrong_type():
@@ -220,6 +226,7 @@ def test_song_from_dict():
             "copyright_text": "",
             "publisher": "",
             "url": "https://open.spotify.com/track/1t2qKa8K72IBC8yQlhD9bU",
+            "popularity": 0,
         }
     )
 
@@ -241,3 +248,4 @@ def test_song_from_dict():
         == "https://i.scdn.co/image/ab67616d0000b273fe2cb38e4d2412dbb0e54332"
     )
     assert song.explicit == False
+    assert song.popularity == 0

--- a/tests/types/test_song.py
+++ b/tests/types/test_song.py
@@ -125,9 +125,9 @@ def test_song_from_search_term():
     assert song.tracks_count == 1
     assert song.isrc == "GB2LD2110301"
     assert song.song_id == "4SN9kQlguIcjPtMNQJwD30"
-    assert song.explicit == False
-    assert song.download_url == None
-    assert song.popularity == 34
+    assert song.explicit is False
+    assert song.download_url is None
+    assert song.popularity is not None and song.popularity >= 0
 
 
 def test_song_from_data_dump():
@@ -183,8 +183,8 @@ def test_song_from_data_dump():
         song.cover_url
         == "https://i.scdn.co/image/ab67616d0000b273fe2cb38e4d2412dbb0e54332"
     )
-    assert song.explicit == False
-    assert song.download_url == None
+    assert song.explicit is False
+    assert song.download_url is None
     assert song.popularity == 0
 
 

--- a/tests/utils/test_metadata.py
+++ b/tests/utils/test_metadata.py
@@ -62,6 +62,7 @@ def test_embed_metadata(tmpdir, monkeypatch, output_format):
         "copyright_text": "",
         "publisher": "",
         "url": "https://open.spotify.com/track/1t2qKa8K72IBC8yQlhD9bU",
+        "popularity": 0,
     }
 
     song = Song.from_dict(song_obj)


### PR DESCRIPTION
Improvements:
- removed original date from id3 tags by @xnetcat in ef2b647d762789a29ff48e1e98222a4691521e66
- improved documentation by @Shabinder and @xnetcat in 7d13e52f10ae45a4b022f047039a5ecd84bccd62 55644854b7752df8e1f1a219d3098e78ed0a7908 a15f7557753117e4701e6b70303c3847d449ab3b
- Include Spotify Popularity in metadata for MP3 files by @cordeliachen in #1827 

Bug fixes:
- check if we get less than 2 template parts by @xnetcat in 1217595fa9e07da45e0d7acc57ed5f500e6f56f2