### PR TITLE
Give an ascii mode to --restrict flag

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -262,7 +262,7 @@ If you don't want config to load automatically change `load_config` option in co
     "filter_results": true,
     "threads": 4,
     "cookie_file": null,
-    "restrict": false,
+    "restrict": null,
     "print_errors": false,
     "sponsor_block": false,
     "preload": false,
@@ -391,7 +391,8 @@ Output options:
                         Path to cookies file.
   --overwrite {metadata,skip,force}
                         How to handle existing/duplicate files. (When combined with --scan-for-songs force will remove all duplicates, and metadata will only apply metadata to the latest song and will remove the rest. )
-  --restrict            Restrict filenames to ASCII only
+  --restrict [{strict,ascii,none}]
+                        Restrict filenames to a sanitized set of characters for increased compatibility
   --print-errors        Print errors (wrong songs, failed downloads etc) on exit, useful for long playlist
   --sponsor-block       Use the sponsor block to download songs from yt/ytm.
   --archive ARCHIVE     Specify the file name for an archive of already downloaded songs

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -33,6 +33,7 @@ from spotdl.utils.archive import Archive
 from spotdl.utils.config import (
     DOWNLOADER_OPTIONS,
     create_settings_type,
+    modernize_settings,
     get_errors_path,
     get_temp_path,
 )
@@ -122,6 +123,8 @@ class Downloader:
             )  # type: ignore
         )
 
+        # Handle deprecated values in config file
+        modernize_settings(self.settings)
         logger.debug("Downloader settings: %s", self.settings)
 
         # If no audio providers specified, raise an error

--- a/spotdl/types/options.py
+++ b/spotdl/types/options.py
@@ -57,7 +57,7 @@ class DownloaderOptions(TypedDict):
     filter_results: bool
     threads: int
     cookie_file: Optional[str]
-    restrict: bool
+    restrict: Optional[str]
     print_errors: bool
     sponsor_block: bool
     preload: bool
@@ -133,7 +133,7 @@ class DownloaderOptionalOptions(TypedDict, total=False):
     filter_results: bool
     threads: int
     cookie_file: Optional[str]
-    restrict: bool
+    restrict: Optional[str]
     print_errors: bool
     sponsor_block: bool
     preload: bool

--- a/spotdl/utils/arguments.py
+++ b/spotdl/utils/arguments.py
@@ -385,12 +385,14 @@ def parse_output_options(parser: _ArgumentGroup):
         type=str,
     )
 
-    # Option to restrict filenames for easier handling in the shell
+    # Option to increase compatibility of filenames and easier handling in the shell
     parser.add_argument(
         "--restrict",
-        action="store_const",
-        const=True,
-        help="Restrict filenames to ASCII only",
+        choices={"strict", "ascii", "none"},
+        const="strict",
+        nargs="?",
+        help="Restrict filenames to a sanitized set of characters for better compatibility",
+        type=str,
     )
 
     # Option to print errors on exit, useful for long playlist

--- a/spotdl/utils/config.py
+++ b/spotdl/utils/config.py
@@ -5,6 +5,7 @@ Default config - spotdl.utils.config.DEFAULT_CONFIG
 """
 
 import json
+import logging
 import os
 import platform
 from argparse import Namespace
@@ -35,6 +36,8 @@ __all__ = [
     "WEB_OPTIONS",
     "DEFAULT_CONFIG",
 ]
+
+logger = logging.getLogger(__name__)
 
 
 class ConfigError(Exception):
@@ -230,6 +233,21 @@ def create_settings(
     return spotify_options, downloader_options, web_options
 
 
+def modernize_settings(options: DownloaderOptions):
+    """Handle deprecated values in config file.
+
+    ### Arguments
+    - options: DownloaderOptions to modernize
+    """
+
+    warning_msg = "Deprecated '%s' value found for '%s' setting in config file. Using '%s' instead."
+
+    # Respect backward compatibility with old boolean --restrict flag
+    if options["restrict"] is True:
+        logger.warning(warning_msg, True, "restrict", "strict")
+        options["restrict"] = "strict"
+
+
 SPOTIFY_OPTIONS: SpotifyOptions = {
     "client_id": "5f573c9620494bae87890c0f08a60293",
     "client_secret": "212476d9b0f3472eaa762d90b19b0ba8",
@@ -259,7 +277,7 @@ DOWNLOADER_OPTIONS: DownloaderOptions = {
     "filter_results": True,
     "threads": 4,
     "cookie_file": None,
-    "restrict": False,
+    "restrict": None,
     "print_errors": False,
     "sponsor_block": False,
     "preload": False,

--- a/spotdl/utils/m3u.py
+++ b/spotdl/utils/m3u.py
@@ -18,7 +18,7 @@ def create_m3u_content(
     song_list: List[Song],
     template: str,
     file_extension: str,
-    restrict: bool = False,
+    restrict: Optional[str] = None,
     short: bool = False,
 ) -> str:
     """
@@ -28,7 +28,7 @@ def create_m3u_content(
     - song_list: the list of songs
     - template: the template to use
     - file_extension: the file extension to use
-    - restrict: whether to sanitize the filename
+    - restrict: sanitization to apply to the filename
     - short: whether to use the short version of the template
 
     ### Returns
@@ -50,7 +50,7 @@ def gen_m3u_files(
     file_name: Optional[str],
     template: str,
     file_extension: str,
-    restrict: bool = False,
+    restrict: Optional[str] = None,
     short: bool = False,
 ):
     """
@@ -62,7 +62,7 @@ def gen_m3u_files(
     - song_list: the list of songs
     - template: the output file template to use
     - file_extension: the file extension to use
-    - restrict: whether to sanitize the filename
+    - restrict: sanitization to apply to the filename
     - short: whether to use the short version of the template
     """
 
@@ -133,7 +133,7 @@ def create_m3u_file(
     song_list: List[Song],
     template: str,
     file_extension: str,
-    restrict: bool = False,
+    restrict: Optional[str] = None,
     short: bool = False,
 ) -> str:
     """
@@ -144,7 +144,7 @@ def create_m3u_file(
     - song_list: the list of songs
     - template: the template to use
     - file_extension: the file extension to use
-    - restrict: whether to sanitize the filename
+    - restrict: sanitization to apply to the filename
     - short: whether to use the short version of the template
 
     ### Returns

--- a/tests/utils/test_formatter.py
+++ b/tests/utils/test_formatter.py
@@ -92,19 +92,60 @@ def test_create_file_name():
     )
 
     assert create_file_name(
-        song, "{title} - {artist}", "mp3", restrict=True, short=False
-    ) == Path("Ropes-Dirty_Palm.mp3")
-
-    assert create_file_name(
-        song, "{title} - {artist}", "mp3", restrict=True, short=True
-    ) == Path("Ropes-Dirty_Palm.mp3")
-
-    assert create_file_name(
         song,
         "{list-position}/{list-length} {title} - {artist}",
         "mp3",
     ) == Path(  # type: ignore
         "05/11 Ropes - Dirty Palm.mp3"
+    )
+
+
+def test_create_file_name_restrict():
+    """
+    Test restrict options in create file name function
+    """
+
+    song = Song.from_dict({
+        'name': 'Crazy - Nôze Remix - Extended Club Version',
+        'artists': ['Ornette'],
+        'artist': 'Ornette',
+        'genres': ['french indie pop'],
+        'disc_number': 1,
+        'disc_count': 1,
+        'album_name': 'Crazy (Nôze Remix)',
+        'album_artist': 'Ornette',
+        'duration': 359.835,
+        'year': 2012,
+        'date': '2012-02-06',
+        'track_number': 2,
+        'tracks_count': 2,
+        'song_id': '5OkuO5pfHG6Gmput8aV4ju',
+        'explicit': False,
+        'publisher': 'Discograph',
+        'url': 'https://open.spotify.com/track/5OkuO5pfHG6Gmput8aV4ju',
+        'isrc': 'FRP211100610',
+        'cover_url': 'https://i.scdn.co/image/ab67616d0000b273336ebd9ff0bfe3fe97652887',
+        'copyright_text': '2012 Discograph',
+        'download_url': None,
+        'lyrics': None,
+        'popularity': 42,
+        'album_id': '5WH54AbrW5ILvVavvuqFwo',
+        'list_name': None,
+        'list_url': None,
+        'list_position': None,
+        'list_length': None
+    })
+
+    assert create_file_name(song, "{artist} - {title}", "mp3", restrict='strict') == Path(
+        "Ornette-Crazy-Noze_Remix-Extended_Club_Version.mp3"
+    )
+
+    assert create_file_name(song, "{artist} - {title}", "mp3", restrict='ascii') == Path(
+        "Ornette - Crazy - Noze Remix - Extended Club Version.mp3"
+    )
+
+    assert create_file_name(song, "{artist} - {title}", "mp3", restrict=None) == Path(
+        "Ornette - Crazy - Nôze Remix - Extended Club Version.mp3"
     )
 
 


### PR DESCRIPTION
## Description
I added the possibility to specify choices to the `--restrict` flag and a new, more lenient `ascii` mode. This mode simply guarantees ASCII characters in filenames instead of the more aggressive sanitization performed by `yt_dlp.utils.sanitize_filename`.

## Related Issue
#1850

## Motivation and Context
Certain programs fail to open filenames that contain special characters but handle whitespaces just fine. Currently, I can use the `--restrict` flag to make filenames contain a sanitized set of characters but then whitespaces are transformed to underscores.

## How Has This Been Tested?
- I run `spotdl <url>` and verified that it doesn't restrict the filename.
- I run `spotdl <url> --restrict` and verified that it preserves the current behavior
- I run `spotdl <url> --restrict=ascii` and verified that it applies a weaker sanitization, simply guaranteeing ASCII characters in the filename.
- I run `spotdl <url> --restrict=none` and verified that it can disable sanitization specified in the `spotdl.config.json` file.
- I verified that an invalid value in `spotdl.config.json` falls back to act as if `--restrict` was not specified.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
