### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -137,7 +137,7 @@ spotDL uses YouTube as a source for music downloads. This method is used to avoi
 
 spotDL downloads music from YouTube and is designed to always download the highest possible bitrate; which is 128 kbps for regular users and 256 kbps for YouTube Music premium users.
 
-Check the [Audio Formats](USAGE#audio-formats-and-quality) page for more info.
+Check the [Audio Formats](usage#audio-formats-and-quality) page for more info.
 
 ## Contributing
 


### PR DESCRIPTION
# Fix broken link in docs

## Description
Since `usage.md` is in lowercase, the link didn't work (https://spotdl.readthedocs.io/en/latest/USAGE#audio-formats-and-quality)