### PR TITLE
Feat: redownload flag for meta

### DIFF
--- a/spotdl/console/meta.py
+++ b/spotdl/console/meta.py
@@ -161,13 +161,17 @@ def meta(query: List[str], downloader: Downloader) -> None:
     
     # to re-download the local songs 
     if downloader.settings["redownload"]:
+        songs_url=[]
         for path in paths:
             meta_data=get_file_metadata(path, downloader.settings["id3_separator"])
             if meta_data.get("url"):
-                songs_list = parse_query(
-                [meta_data["url"]],
-                downloader.settings["threads"],
-                downloader.settings["ytm_data"],
-                downloader.settings["playlist_numbering"],
-                )
-                downloader.download_multiple_songs(songs_list)
+                songs_url.append(meta_data.get("url"))
+
+        songs_list = parse_query(
+        songs_url,
+        downloader.settings["threads"],
+        downloader.settings["ytm_data"],
+        downloader.settings["playlist_numbering"],
+        )
+        
+        downloader.download_multiple_songs(songs_list)

--- a/spotdl/types/options.py
+++ b/spotdl/types/options.py
@@ -77,6 +77,7 @@ class DownloaderOptions(TypedDict):
     yt_dlp_args: Optional[str]
     detect_formats: Optional[List[str]]
     save_errors: Optional[str]
+    redownload: bool
 
 
 class WebOptions(TypedDict):

--- a/spotdl/utils/arguments.py
+++ b/spotdl/utils/arguments.py
@@ -541,6 +541,14 @@ def parse_output_options(parser: _ArgumentGroup):
         ),
         choices=FFMPEG_FORMATS.keys(),
     )
+ 
+    # download song in meta operation
+    parser.add_argument(
+        "--redownload",
+        action="store_const",
+        const=True,
+        help="to redownload the local song in diffrent format using --format for meta operation",
+    )
 
 
 def parse_web_options(parser: _ArgumentGroup):

--- a/spotdl/utils/config.py
+++ b/spotdl/utils/config.py
@@ -297,6 +297,7 @@ DOWNLOADER_OPTIONS: DownloaderOptions = {
     "yt_dlp_args": None,
     "detect_formats": None,
     "save_errors": None,
+    "redownload":None,
 }
 
 WEB_OPTIONS: WebOptions = {


### PR DESCRIPTION
# Redownload feature for meta operation
user will be able to re-download the local songs in different format

### Description
using the redownload flag and format flag to download  local songs using meta operation

## Motivation and Context
now users don't need to find the link of the song to change the format they can now use the redownload flag with the format flag under the meta operation

## Screenshots
![Screenshot 2023-10-27 203220](https://github.com/spotDL/spotify-downloader/assets/90760974/717b3b27-57f4-4c1e-a260-d8c18f134e55)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
