### PR TITLE
Fix SSLError and TypeError when fetching synced lyrics

### DIFF
--- a/spotdl/providers/lyrics/synced.py
+++ b/spotdl/providers/lyrics/synced.py
@@ -2,9 +2,8 @@
 Synced lyrics provider using the syncedlyrics library
 """
 
-from typing import Dict, List, Optional
-
 import syncedlyrics
+from typing import Dict, List, Optional
 
 from spotdl.providers.lyrics.base import LyricsProvider
 
@@ -46,7 +45,7 @@ class Synced(LyricsProvider):
 
         raise NotImplementedError
 
-    def get_lyrics(self, name: str, artists: List[str], **_) -> Optional[str]:
+    def get_lyrics(self, name: str, artists: List[str], **kwargs) -> Optional[str]:
         """
         Try to get lyrics using syncedlyrics
 
@@ -59,6 +58,19 @@ class Synced(LyricsProvider):
         - The lyrics of the song or None if no lyrics were found.
         """
 
-        lyrics = syncedlyrics.search(f"{name} - {artists[0]}", allow_plain_format=True)
-
-        return lyrics
+        try:
+            lyrics = syncedlyrics.search(f"{name} - {artists[0]}",
+                                         allow_plain_format=kwargs.get("allow_plain_format", True))
+            return lyrics
+        except requests.exceptions.SSLError:
+            # Max retries reached
+            return None
+        except TypeError:
+            # Error at syncedlyrics.providers.musixmatch L89 - Because `body` is occasionally an empty list
+            # instead of a dictionary.
+            # We get this error when allow_plain_format is set to True, and there are no synced lyrics present
+            # Because its empty, we know there are no lyrics
+            return None
+        except:
+            # Potential unhandled exceptions caused by syncedlyrics
+            return None

--- a/spotdl/providers/lyrics/synced.py
+++ b/spotdl/providers/lyrics/synced.py
@@ -68,11 +68,11 @@ class Synced(LyricsProvider):
             # Max retries reached
             return None
         except TypeError:
-            # Error at syncedlyrics.providers.musixmatch L89 - Because `body` is occasionally an empty list
-            # instead of a dictionary.
-            # We get this error when allow_plain_format is set to True, and there are no synced lyrics present
+            # Error at syncedlyrics.providers.musixmatch L89 -
+            #   Because `body` is occasionally an empty list instead of a dictionary.
+            # We get this error when allow_plain_format is set to True,
+            #   and there are no synced lyrics present
             # Because its empty, we know there are no lyrics
             return None
-        except:
-            # Potential unhandled exceptions caused by syncedlyrics
+        finally:
             return None

--- a/spotdl/providers/lyrics/synced.py
+++ b/spotdl/providers/lyrics/synced.py
@@ -74,5 +74,3 @@ class Synced(LyricsProvider):
             #   and there are no synced lyrics present
             # Because its empty, we know there are no lyrics
             return None
-        finally:
-            return None

--- a/spotdl/providers/lyrics/synced.py
+++ b/spotdl/providers/lyrics/synced.py
@@ -61,8 +61,10 @@ class Synced(LyricsProvider):
         """
 
         try:
-            lyrics = syncedlyrics.search(f"{name} - {artists[0]}",
-                                         allow_plain_format=kwargs.get("allow_plain_format", True))
+            lyrics = syncedlyrics.search(
+                f"{name} - {artists[0]}",
+                allow_plain_format=kwargs.get("allow_plain_format", True),
+            )
             return lyrics
         except requests.exceptions.SSLError:
             # Max retries reached

--- a/spotdl/providers/lyrics/synced.py
+++ b/spotdl/providers/lyrics/synced.py
@@ -2,8 +2,10 @@
 Synced lyrics provider using the syncedlyrics library
 """
 
-import syncedlyrics
 from typing import Dict, List, Optional
+
+import requests
+import syncedlyrics
 
 from spotdl.providers.lyrics.base import LyricsProvider
 


### PR DESCRIPTION
# Title
Fix SSLError and TypeError when fetching synced lyrics

## Description
When using `syncedlyrics`, an unexpected `IndexError` is encountered when it does not work as intended. This PR fixes the issue by handling it, along with handling the `SSLError` when max retries are reached, which can be caused by reasons other than network issues (Source: It happened to me) 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [?] All new and existing tests passed
