### PR TITLE
Fix performance issue when ffmpeg outputs a lot of lines

### DIFF
--- a/spotdl/utils/ffmpeg.py
+++ b/spotdl/utils/ffmpeg.py
@@ -366,7 +366,6 @@ def convert(
 
         out_buffer = []
         total_dur = None
-        out: str = ""
         while True:
             if process.stdout is None:
                 continue
@@ -379,8 +378,6 @@ def convert(
                 break
 
             out_buffer.append(out_line.strip())
-
-            out = "\n".join(out_buffer)
 
             total_dur_match = DUR_REGEX.search(out_line)
             if total_dur is None and total_dur_match:
@@ -402,7 +399,7 @@ def convert(
                 "ffmpeg": ffmpeg,
                 "version": version[0],
                 "build_year": version[1],
-                "error": out,
+                "error": "\n".join(out_buffer),
             }
 
         progress_handler(100)


### PR DESCRIPTION
# Title

Change the python code that records the ffmpeg output to not unnecessarily construct a new string of the entire output every time a new line is read from the process. Instead, construct the string only once at the end, if it is needed.

## Description

Before this patch the `out` string was constructed in a loop every time a new line was read, which requires O(n^2) time where n is the number of lines in the output. For every loop iteration, the `"\n".join(out_buffer)` code constructed a new string by iterating over all the recorded lines so far. This patch reduces the time complexity to O(n) because the output string is constructed outside of the loop.

Spotdl runs ffmpeg with debug logging level, which can result in a lot of recorded output. For example, running the `test_download_song` test in `test_entry_point.py` on my Linux system with ffmpeg 6.1.1 makes ffmpeg output a total of 13 MiB of messages, consisting of almost 179 000 lines.

This fix reduces the time needed for `test_download_song` from 779 s to 10 s on my machine, which is a 99% performance increase.

## Related Issue

This could be related to #1987, however I haven't tested this on Windows.

## Motivation and Context

A 10 seconds download time for one song is much more manageable than 10 minutes.

## How Has This Been Tested?

Tested by running `pytest tests/console/test_entry_point.py::test_download_song`. The amount of ffmpeg output might be affected by my global spotdl config which sets the output file format to ogg. The ffmpeg output line count was recorded by running the used ffmpeg command manually.

Without this patch spotdl would consume 100% processor time on one CPU, while the ffmpeg process was mostly idle.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
