### PR TITLE
Fixing termux installation

### DIFF
--- a/scripts/termux.sh
+++ b/scripts/termux.sh
@@ -5,10 +5,7 @@ termux-setup-storage
 pkg update -y
 
 # install python and ffmpeg
-pkg install -y python ffmpeg
-
-# install setuptools
-pip install setuptools
+pkg install -y python ffmpeg rust binutils
 
 # install spotdl
 pip install -U spotdl


### PR DESCRIPTION
Description:
After re-evaluating the script in a clean Termux environment, several changes were identified to ensure its proper functionality. 
The script consistently encountered a compiler error when attempting to build the dependencies of the pydatic component. 
This issue stems from a combination of a Rust error and the native environment of Termux.

Changes:
Dependencies:
The script requires the Rust package to be installed to facilitate proper compilation.
Additionally, the binutils package is necessary for correct functionality.
The setuptools package is deemed unnecessary and has been removed.

Please review and merge as appropriate. 
Thank you!