### PR TITLE
Download lyrics with save operation

### DIFF
--- a/spotdl/console/save.py
+++ b/spotdl/console/save.py
@@ -51,20 +51,36 @@ def save(
     save_data = [song.json for song in songs]
 
     def process_song(song: Song):
-        try:
-            data = downloader.search(song)
-            if data is None:
-                logger.error("Could not find a match for %s", song.display_name)
+        download_url = None
+        if downloader.settings["preload"]:
+            try:
+                download_url = downloader.search(song)
+                if download_url is None:
+                    logger.error("Could not find a match for %s", song.display_name)
+                    return None
 
+                logger.info("Found url for %s: %s", song.display_name, download_url)
+            except Exception as exception:
+                logger.error(
+                    "%s generated an exception: %s", song.display_name, exception
+                )
                 return None
 
-            logger.info("Found url for %s: %s", song.display_name, data)
-
-            return {**song.json, "download_url": data}
+        lyrics = None
+        try:
+            lyrics = downloader.search_lyrics(song)
+            if lyrics is None:
+                logger.debug(
+                    "No lyrics found for %s, lyrics providers: %s",
+                    song.display_name,
+                    ", ".join(
+                        [lprovider.name for lprovider in downloader.lyrics_providers]
+                    ),
+                )
         except Exception as exception:
-            logger.error("%s generated an exception: %s", song.display_name, exception)
+            logger.debug("Could not search for lyrics: %s", exception)
 
-        return None
+        return {**song.json, "download_url": download_url, "lyrics": lyrics}
 
     async def pool_worker(song: Song):
         async with downloader.semaphore:
@@ -74,11 +90,10 @@ def save(
             # hurt performance.
             return await downloader.loop.run_in_executor(None, process_song, song)
 
-    if downloader.settings["preload"]:
-        tasks = [pool_worker(song) for song in songs]
+    tasks = [pool_worker(song) for song in songs]
 
-        # call all task asynchronously, and wait until all are finished
-        save_data = list(downloader.loop.run_until_complete(asyncio.gather(*tasks)))
+    # call all task asynchronously, and wait until all are finished
+    save_data = list(downloader.loop.run_until_complete(asyncio.gather(*tasks)))
 
     if to_stdout:
         # Print the songs to stdout


### PR DESCRIPTION
# Download lyrics with save operation

## Description
Save operation in version 4.2.8 doesn't download lyrics from lyrics providers. I copied this feature from downloader.py -> search_and_download() and refactored save operation code a bit.

## Related Issue
#2151

## Motivation and Context
Allows for downloading song lyrics, without need to download entire track.

## How Has This Been Tested?
Ran save operation on version 4.2.8 and my commit, then compared save-file outputs.
Also compared download operation using --save-file argument to be sure.
Checked cases both with and without --preload argument.
I only notice change in availability of lyrics in save-file after save operation.

Environment:
Python 3.12.6
Venv

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project --- ran pylint, black and mypy
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document --- is it renamed to CODE_OF_CONDUCT.md?
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed - 1 failed, although it also fails on main branch
