### PR TITLE
Add Metadata to Playlist Files

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -281,6 +281,7 @@ If you don't want config to load automatically change `load_config` option in co
     "scan_for_songs": false,
     "m3u": null,
     "output": "{artists} - {title}.{output-ext}",
+    "m3u_output": "#EXTINF:{duration}, {artists} - {title}.{output-ext}",
     "overwrite": "skip",
     "search_query": null,
     "ffmpeg": "ffmpeg",
@@ -463,6 +464,8 @@ Output options:
   --sponsor-block       Use the sponsor block to download songs from yt/ytm.
   --archive ARCHIVE     Specify the file name for an archive of already downloaded songs
   --playlist-numbering  Sets each track in a playlist to have the playlist's name as its album, and album art as the playlist's icon
+  --playlist-retain-track-cover
+                        Sets each track in a playlist to have the playlist's name as its album, while retaining album art of each track
   --scan-for-songs      Scan the output directory for existing files. This option should be combined with the --overwrite option to control how existing files are handled. (Output
                         directory is the last directory that is not a template variable in the output template)
   --fetch-albums        Fetch all albums from songs in query

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -464,8 +464,6 @@ Output options:
   --sponsor-block       Use the sponsor block to download songs from yt/ytm.
   --archive ARCHIVE     Specify the file name for an archive of already downloaded songs
   --playlist-numbering  Sets each track in a playlist to have the playlist's name as its album, and album art as the playlist's icon
-  --playlist-retain-track-cover
-                        Sets each track in a playlist to have the playlist's name as its album, while retaining album art of each track
   --scan-for-songs      Scan the output directory for existing files. This option should be combined with the --overwrite option to control how existing files are handled. (Output
                         directory is the last directory that is not a template variable in the output template)
   --fetch-albums        Fetch all albums from songs in query

--- a/spotdl/console/save.py
+++ b/spotdl/console/save.py
@@ -92,7 +92,7 @@ def save(
         gen_m3u_files(
             songs,
             m3u_file,
-            downloader.settings["output"],
+            downloader.settings["m3u_output"],
             downloader.settings["format"],
             downloader.settings["restrict"],
             False,

--- a/spotdl/console/sync.py
+++ b/spotdl/console/sync.py
@@ -79,7 +79,7 @@ def sync(
             gen_m3u_files(
                 songs_list,
                 m3u_file,
-                downloader.settings["output"],
+                downloader.settings["m3u_output"],
                 downloader.settings["format"],
                 downloader.settings["restrict"],
                 False,
@@ -226,7 +226,7 @@ def sync(
             gen_m3u_files(
                 songs_playlist,
                 m3u_file,
-                downloader.settings["output"],
+                downloader.settings["m3u_output"],
                 downloader.settings["format"],
                 downloader.settings["restrict"],
                 False,

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -336,7 +336,7 @@ class Downloader:
             gen_m3u_files(
                 song_list,
                 self.settings["m3u"],
-                self.settings["output"],
+                self.settings["m3u_output"],
                 self.settings["format"],
                 self.settings["restrict"],
                 False,

--- a/spotdl/types/options.py
+++ b/spotdl/types/options.py
@@ -48,6 +48,7 @@ class DownloaderOptions(TypedDict):
     scan_for_songs: bool
     m3u: Optional[str]
     output: str
+    m3u_output: str
     overwrite: str
     search_query: Optional[str]
     ffmpeg: str

--- a/spotdl/utils/config.py
+++ b/spotdl/utils/config.py
@@ -312,6 +312,7 @@ DOWNLOADER_OPTIONS: DownloaderOptions = {
     "scan_for_songs": False,
     "m3u": None,
     "output": "{artists} - {title}.{output-ext}",
+    "m3u_output": "#EXTINF:{duration}, {artists} - {title}.{output-ext}",
     "overwrite": "skip",
     "search_query": None,
     "ffmpeg": "ffmpeg",

--- a/tests/types/test_artist.py
+++ b/tests/types/test_artist.py
@@ -63,5 +63,5 @@ def test_artist_from_string():
 
     artist = Artist.from_search_term("artist: gorillaz")
     assert artist.name.lower().startswith("gor")
-    assert artist.url == "http://open.spotify.com/artist/3zcOegUrWqti1S0lu4juJz"
+    assert artist.url == "http://open.spotify.com/artist/3AA28KZvwAUcZuOKwyblJQ"
     assert len(artist.urls) > 1

--- a/tests/types/test_artist.py
+++ b/tests/types/test_artist.py
@@ -63,5 +63,5 @@ def test_artist_from_string():
 
     artist = Artist.from_search_term("artist: gorillaz")
     assert artist.name.lower().startswith("gor")
-    assert artist.url == "http://open.spotify.com/artist/3AA28KZvwAUcZuOKwyblJQ"
+    assert artist.url == "http://open.spotify.com/artist/3zcOegUrWqti1S0lu4juJz"
     assert len(artist.urls) > 1


### PR DESCRIPTION
# Title
Add Metadata to Playlist Files

## Description
Adding new setting to enhance the playlist (M3U) file generation by including #EXTINF metadata tag.

## Related Issue
#2126

## Motivation and Context
Enhanceing playlist (M3U) file generation by including #EXTINF metadata tag . This would enrich the playlist files by including additional information like track duration and title, thereby providing a better user experience.

## How Has This Been Tested?
Ran spotDL many times, to test various scenarios

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
