### PR TITLE
Fixes: #2212 ; Feature: Skip Duplicate Song from Sub-Folders ; Fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ temp/
 # VS Code
 .vscode
 *.txt
+
+# Output Folder
+output/

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -454,6 +454,18 @@ class Downloader:
                 restrict=self.settings["restrict"],
                 file_name_length=self.settings["max_filename_length"],
             )
+
+            # Update output path using song.album_name if valid; otherwise, use song.artist.
+            output_file = (
+                Path("output")
+                / (
+                    Path(song.album_name)
+                    if Path(song.album_name).is_dir()
+                    else Path(song.artist)
+                )
+                / output_file
+            )
+
         except Exception:
             song = reinit_song(song)
 
@@ -463,6 +475,17 @@ class Downloader:
                 file_extension=self.settings["format"],
                 restrict=self.settings["restrict"],
                 file_name_length=self.settings["max_filename_length"],
+            )
+
+            # Update output path using song.album_name if valid; otherwise, use song.artist.
+            output_file = (
+                Path("output")
+                / (
+                    Path(song.album_name)
+                    if Path(song.album_name).is_dir()
+                    else Path(song.artist)
+                )
+                / output_file
             )
 
             reinitialized = True
@@ -483,14 +506,14 @@ class Downloader:
             dup_song_paths: List[Path] = self.known_songs.get(song.url, [])
 
             # Remove files from the list that have the same path as the output file
-            dup_song_paths = [
-                dup_song_path
-                for dup_song_path in dup_song_paths
-                if (dup_song_path.absolute() != output_file.absolute())
-                and dup_song_path.exists()
-            ]
+            dup_song_paths = list(Path(output_file.parts[0]).rglob(output_file.name))
 
-            file_exists = output_file.exists() or dup_song_paths
+            # Checking if file already exists in all subfolders of output directory
+            file_exists = (
+                next(Path(output_file.parts[0]).rglob(output_file.name), None)
+                or dup_song_paths
+            )
+
             if not self.settings["scan_for_songs"]:
                 for file_extension in self.scan_formats:
                     ext_path = output_file.with_suffix(f".{file_extension}")
@@ -566,7 +589,7 @@ class Downloader:
                         logger.info("Removing duplicate file: %s", dup_song_path)
 
                         dup_song_path.unlink()
-                    except (PermissionError, OSError) as exc:
+                    except (PermissionError, OSError, Exception) as exc:
                         logger.debug(
                             "Could not remove duplicate file: %s, error: %s",
                             dup_song_path,


### PR DESCRIPTION
# Title
Fixes: #2212 ; Feature: Skip Duplicate Song from Sub-Folders ; Fixed

## Description
This PR Fixes the issue of re-downloading duplicate songs if they exist in subfolders and fixed the output structure for downloaded files

## Related Issue
Fixes: #2212 

## Motivation and Context
User faces problem in skipping duplicate files present in subfolders and a generalized folder structure, so this PR fixed this problem

## How Has This Been Tested?
Performed download testing with different overwrite options to check working of the updated code 

## Types of Changes
- [x] Feature: Updated Code for Skipping Downloading of duplicate files from the subfolders 

## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
