### PR TITLE
Fix flac scanning when no album art present

### DIFF
--- a/spotdl/utils/metadata.py
+++ b/spotdl/utils/metadata.py
@@ -444,9 +444,8 @@ def get_file_metadata(path: Path, id3_separator: str = "/") -> Optional[Dict[str
 
                 continue
 
-            if path.suffix == ".flac":
-                if len(audio_file.pictures) > 0:
-                    song_meta["album_art"] = audio_file.pictures[0].data
+            if path.suffix == ".flac" and len(audio_file.pictures) > 0:
+                song_meta["album_art"] = audio_file.pictures[0].data
                 continue
 
             if path.suffix in [".ogg", ".opus"]:

--- a/spotdl/utils/metadata.py
+++ b/spotdl/utils/metadata.py
@@ -445,7 +445,8 @@ def get_file_metadata(path: Path, id3_separator: str = "/") -> Optional[Dict[str
                 continue
 
             if path.suffix == ".flac":
-                song_meta["album_art"] = audio_file.pictures[0].data
+                if len(audio_file.pictures) > 0:
+                    song_meta["album_art"] = audio_file.pictures[0].data
                 continue
 
             if path.suffix in [".ogg", ".opus"]:


### PR DESCRIPTION
# Fix flac scanning when no album art present

## Description
If existing flac files don't have images attached to them, spotdl crashes. This fixes that.

## Related Issue
Fixes #2237

## Motivation and Context
Fixes a bug

## How Has This Been Tested?
I used it, and it fixes the bug

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
