### PR TITLE
fix: genius scrapper lyrics container div

### DIFF
--- a/spotdl/providers/lyrics/genius.py
+++ b/spotdl/providers/lyrics/genius.py
@@ -112,12 +112,15 @@ class Genius(LyricsProvider):
 
         lyrics_div = soup.select_one("div.lyrics")
         lyrics_containers = soup.select("div[class^=Lyrics__Container]")
+        lyrics_container = soup.find("div", {"data-lyrics-container": "true"})
 
         # Get lyrics
         if lyrics_div:
             lyrics = lyrics_div.get_text()
         elif lyrics_containers:
             lyrics = "\n".join(con.get_text() for con in lyrics_containers)
+        elif lyrics_container: 
+            lyrics = lyrics_container.get_text("\n")
         else:
             return None
 


### PR DESCRIPTION
# Title
Fix genius scrapper

## Description
The genius website seem to have changed breaking the download lyrics feature. It looks like the HTML structure of the Genius lyrics page has changed. The new lyrics container is now wrapped in a div with data-lyrics-container="true".

## Related Issue
https://github.com/spotDL/spotify-downloader/issues/2302

## Motivation and Context
It fix the genius scrapping for lyrics

## How Has This Been Tested?
Locally with simple tests

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [X] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
