### PR TITLE
Provide correct video duration for YouTube audio provider

### DIFF
--- a/spotdl/providers/audio/youtube.py
+++ b/spotdl/providers/audio/youtube.py
@@ -50,9 +50,6 @@ class YouTube(AudioProvider):
         - A list of YouTube results if found, None otherwise.
         """
 
-        search = Search(search_term)
-        # patch pytube client versioning issue that does not return
-        # the correct video duration
         patch_innertube_webclient_version()
         search_results: Optional[List[PyTube]] = Search(search_term).results
 

--- a/spotdl/providers/audio/youtube.py
+++ b/spotdl/providers/audio/youtube.py
@@ -4,6 +4,7 @@ Youtube module for downloading and searching songs.
 
 from typing import Any, Dict, List, Optional
 
+import pytube.innertube
 from pytube import Search
 from pytube import YouTube as PyTube
 
@@ -11,6 +12,19 @@ from spotdl.providers.audio.base import AudioProvider
 from spotdl.types.result import Result
 
 __all__ = ["YouTube"]
+
+
+def patch_innertube_webclient_version():
+    """
+    Patch pytube client versioning issue that does not return
+    the correct video duration.
+    """
+    # This is a workaround for the issue described in https://github.com/pytube/pytube/issues/296
+    try:
+        pytube.innertube._default_clients['WEB']["context"]["client"]["clientVersion"] = "2.20230427.04.00"
+        return True
+    except:
+        return False
 
 
 class YouTube(AudioProvider):
@@ -36,6 +50,10 @@ class YouTube(AudioProvider):
         - A list of YouTube results if found, None otherwise.
         """
 
+        search = Search(search_term)
+        # patch pytube client versioning issue that does not return
+        # the correct video duration
+        patch_innertube_webclient_version()
         search_results: Optional[List[PyTube]] = Search(search_term).results
 
         if not search_results:


### PR DESCRIPTION

# Title
Provide correct video duration for YouTube audio provider

## Description
The `YouTube` audio provider relies on `pytube`'s `Search` object, whose default settings uses an older version of the WEB client. This throws an exception when retrieving the video duration. 

Upgrading the WEB client version fixes the issue. See more here: https://github.com/pytube/pytube/issues/296

## Related Issue
#2323

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
