### PR TITLE
Remove unwanted radio edits from search #2181

### DIFF
--- a/spotdl/utils/matching.py
+++ b/spotdl/utils/matching.py
@@ -577,6 +577,15 @@ def calc_name_match(
     - name match percentage
     """
 
+    # Remove unwanted Radio Edits
+    song_title_disallowed = ["radio edit", "karaoke", "instrumental", "radioedit", "radio version"]
+    result_name_lower = result.name.lower()
+    song_name_lower = song.name.lower()
+    
+    if any(phrase in result_name_lower for phrase in song_title_disallowed) or any (phrase in song_name_lower for phrase in song_title_disallowed):
+        return 0.0;
+
+
     # Create match strings that will be used
     # to calculate name match value
     match_str1, match_str2 = create_match_strings(song, result, search_query)


### PR DESCRIPTION
# Title
Returns a title / song match of 0 when radio edit, instrumental, karaoke, etc. is in title. 

## Description
Checks if song title matches any of the forbidden words (radio edit, etc). If that is the case, it gives out a score of 0. 

## Related Issue
https://github.com/spotDL/spotify-downloader/issues/2181#issuecomment-2722652722
#2181 

## Motivation and Context
It makes sure that full versions are preferred over radio edits as requested by issue opener. 

## How Has This Been Tested?
I ran the application with provided instructions and no longer received radio edits when downloading songs. 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ X ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ X ] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ X ] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ X ] I have added tests to cover my changes
- [ X ] All new and existing tests passed
