### PR TITLE
Update downloader.py

### DIFF
--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -737,7 +737,7 @@ class Downloader:
                     bitrate = (
                         f"{int(download_info['abr'])}k"
                         if download_info.get("abr")
-                        else "copy"
+                        else "320k"
                     )
                 elif self.settings["bitrate"] == "disable":
                     bitrate = None


### PR DESCRIPTION
Set default fallback audio bitrate when no abr (assume available Bir rate) is found or null. from else "copy" => else "320k"

# Title
Missing fallback bitrate

## Description
ffmpeg was failing when no bitrate was sent it was receiving "copy" vs bitrate and ffmpeg needs -c for copy. changed else to fall back to 320k

## Related Issue
#2364

## Motivation and Context
ffmpeg will not make output file as script doesnt have fallback bitrate

## How Has This Been Tested?
cli python3

## Types of Changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x ] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [ x] All new and existing tests passed
