### PR TITLE
Restrict bitrate condition to m4a and opus formats in convert

### DIFF
--- a/spotdl/utils/ffmpeg.py
+++ b/spotdl/utils/ffmpeg.py
@@ -316,13 +316,15 @@ def convert(
             arguments.extend(FFMPEG_FORMATS[output_format])
 
     # Add bitrate if specified
-    if bitrate and output_format in ["m4a", "opus"]:
+    if bitrate and bitrate != "copy":
         # Check if bitrate is an integer
         # if it is then use it as variable bitrate
         if bitrate.isdigit():
             arguments.extend(["-q:a", bitrate])
         else:
             arguments.extend(["-b:a", bitrate])
+    elif bitrate == "copy" and output_format in ["m4a", "opus"]:
+        arguments.extend(["-vn", "-c:a", "copy"])
 
     # Add other ffmpeg arguments if specified
     if ffmpeg_args:

--- a/spotdl/utils/ffmpeg.py
+++ b/spotdl/utils/ffmpeg.py
@@ -316,7 +316,7 @@ def convert(
             arguments.extend(FFMPEG_FORMATS[output_format])
 
     # Add bitrate if specified
-    if bitrate:
+    if bitrate and output_format in ["m4a", "opus"]:
         # Check if bitrate is an integer
         # if it is then use it as variable bitrate
         if bitrate.isdigit():


### PR DESCRIPTION
# Title

## Description
this will fix the invalid bitrate when there is no bitrate provided in either cli or config by just omitting the bitrate argument completely since ffmpeg automatically handles it.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/spotDL/spotify-downloader/issues/2333

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
