### PR TITLE
fix: Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,13 @@ RUN apk add --no-cache \
 # Install uv and update pip/wheel
 RUN pip install --upgrade pip uv wheel spotipy
 
+# Set workdir
+WORKDIR /app
+
 # Copy requirements files
-COPY uv.lock pyproject.toml /
+COPY . .
 
 # Install spotdl requirements
-RUN uv sync
-
-# Add source code files to WORKDIR
-ADD . .
-
-# Install spotdl itself
 RUN uv sync
 
 # Create music directory
@@ -34,9 +31,6 @@ RUN mkdir /music
 
 # Create a volume for the output directory
 VOLUME /music
-
-# Change CWD to /music
-WORKDIR /music
 
 # Entrypoint command
 ENTRYPOINT ["uv", "run", "spotdl"]


### PR DESCRIPTION
# Fixed Dockerfile build issues
The Dockerfile does contain some issues:
- files are copied into root dir  leading to build issues with uv sync (missing files mainly)
- no workdir is set while building
- uv sync run multiple times

## Description
Addressed above changes as follows:
change to workdir earlier, copy all files from git, build via uv sync

## Related Issue

## How Has This Been Tested?
Tested on RPI4, Ubuntu Sever 24.04

## Types of Changes
- [X] Bug fix (non-breaking change which fixes an issue)
