### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN pip install --upgrade pip uv wheel spotipy
 COPY uv.lock pyproject.toml /
 
 # Install spotdl requirements
-RUN uv sync
+RUN uv sync --no-install-project
 
 # Add source code files to WORKDIR
 ADD . .


### PR DESCRIPTION
# Update Docker build commands

## Description
Fix incorrect command that tries to install project too early.
Keeping both syncs is better for docker (dependencies change less often usually.)
But since this file was designed, uv now errors if it cannot also build the project at the same time without this flag.

## Related Issue
https://github.com/spotDL/spotify-downloader/issues/2300

## Motivation and Context
Fixes automatic docker build.

## How Has This Been Tested?
Ran the docker build locally.

## Screenshots (if appropriate)

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
