### PR TITLE
Fix `extractor_args` being the wrong type by removing it

### DIFF
--- a/spotdl/providers/audio/base.py
+++ b/spotdl/providers/audio/base.py
@@ -109,7 +109,6 @@ class AudioProvider:
             "cookiefile": self.cookie_file,
             "outtmpl": str((get_temp_path() / "%(id)s.%(ext)s").resolve()),
             "retries": 5,
-            "extractor_args": [],
         }
 
         if yt_dlp_args:


### PR DESCRIPTION
# Title
See #2432.

## Description
A commit (ad48f5c) 7 months ago set `extractor_args` (yt-dlp parameter) to `[]`, when it should be a dictionary. I assume this just recently got into a release, since a few people have been complaining about issues caused by this.

This PR reverts the problematic commit, leaving `extractor_args` to default to `{}`.

## Related Issue
#2432

## Motivation and Context
It allows users to use spotdl with youtube.

## How Has This Been Tested?
```sh
$ uv sync
...
$ uv run scripts/build.py
...
$ dist/spotdl-4.3.0-linux download 'primus too many puppies'
... (it worked)
```

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
