### PR TITLE
Fix azlyrics logic, and disable it temporarily

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -282,7 +282,6 @@ If you don't want config to load automatically change `load_config` option in co
     ],
     "lyrics_providers": [
         "genius",
-        "azlyrics",
         "musixmatch"
     ],
     "playlist_numbering": false,

--- a/spotdl/providers/lyrics/azlyrics.py
+++ b/spotdl/providers/lyrics/azlyrics.py
@@ -4,13 +4,14 @@ AZLyrics lyrics module.
 
 from typing import Dict, List, Optional
 
+import logging
 import requests
 from bs4 import BeautifulSoup
 
 from spotdl.providers.lyrics.base import LyricsProvider
 
 __all__ = ["AzLyrics"]
-
+logger = logging.getLogger(__name__)
 
 class AzLyrics(LyricsProvider):
     """
@@ -37,7 +38,9 @@ class AzLyrics(LyricsProvider):
         ### Returns
         - A dictionary with the results. (The key is the title and the value is the url.)
         """
-
+        logger.warning("WARNING: AZLyrics is currently dysfunctional but selected, skipping. Overwrite your existing config file with `spotdl --generate-config`, or manually  remove it as a lyrics provider.")
+        return {}
+    
         if self.x_code is None:
             self.x_code = self.get_x_code()
 

--- a/spotdl/providers/lyrics/azlyrics.py
+++ b/spotdl/providers/lyrics/azlyrics.py
@@ -60,6 +60,7 @@ class AzLyrics(LyricsProvider):
                     "https://search.azlyrics.com/search.php", params=params
                 )
             except requests.ConnectionError:
+                counter += 1
                 continue
 
             if not response.ok:

--- a/spotdl/providers/lyrics/azlyrics.py
+++ b/spotdl/providers/lyrics/azlyrics.py
@@ -38,7 +38,7 @@ class AzLyrics(LyricsProvider):
         ### Returns
         - A dictionary with the results. (The key is the title and the value is the url.)
         """
-        logger.warning("WARNING: AZLyrics is currently dysfunctional but selected, skipping. Overwrite your existing config file with `spotdl --generate-config`, or manually  remove it as a lyrics provider.")
+        logger.warning("WARNING: AZLyrics is currently dysfunctional but selected, skipping. Overwrite your existing config file with `spotdl --generate-config`, or manually remove it as a lyrics provider.")
         return {}
     
         if self.x_code is None:

--- a/spotdl/utils/config.py
+++ b/spotdl/utils/config.py
@@ -306,7 +306,7 @@ SPOTIFY_OPTIONS: SpotifyOptions = {
 
 DOWNLOADER_OPTIONS: DownloaderOptions = {
     "audio_providers": ["youtube-music"],
-    "lyrics_providers": ["genius", "azlyrics", "musixmatch"],
+    "lyrics_providers": ["genius", "musixmatch"],
     "genius_token": "alXXDbPZtK1m2RrZ8I4k2Hn8Ahsd0Gh_o076HYvcdlBvmc0ULL1H8Z8xRlew5qaG",
     "playlist_numbering": False,
     "playlist_retain_track_cover": False,


### PR DESCRIPTION
# Title
<!--- Provide a general summary of your changes in the Title above -->
Fix azlyrics logic, and disable it temporarily
## Description
<!--- Describe your changes in detail -->
AZlyrics logic error causing endless loop is resolved.
Also the API has been killed, so disable AZlyrics lyrics provider for now, and also include a warning msg to users with it in their default config.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2439 and subsequent #2441

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
logic error in v4.3.0, where the counter is not incremented on line 62-63 leads to an endless loop.
https://github.com/spotDL/spotify-downloader/blob/5266ddb85fd182a5b357b553fd0ddec9eb0f0cd7/spotdl/providers/lyrics/azlyrics.py#L57-L67

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

as usual


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
