### PR TITLE
Refine song reinitialization logic in search_and_download function

### DIFF
--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -447,21 +447,12 @@ class Downloader:
             return song, None
 
         # Reinitialize the song object if it's missing metadata
-        # Or if we are fetching albums
+        # Only reinitialize if critical fields are missing or fetch_albums is set
         if (
             (song.name is None and song.url)
             or self.settings["fetch_albums"]
-            or any(
-                x is None
-                for x in [
-                    song.genres,
-                    song.disc_count,
-                    song.tracks_count,
-                    song.track_number,
-                    song.album_id,
-                    song.album_artist,
-                ]
-            )
+            or (song.artists is None and song.artist is None)
+            or (song.url is None and song.song_id is None)
         ):
             song = reinit_song(song)
 


### PR DESCRIPTION
# Fix too many song reint causing rate limiting
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes logic in search_and_download to only reint a song if critical fields are missing, instead of also optional ones.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/spotDL/spotify-downloader/issues/2420#issuecomment-3201767695

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Started to hit spotify rate limits since v4.3.1 when downloading a large playlist with most songs already present.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Installed master branch with change locally and downloaded playlist

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
