### PR TITLE
Utilise GH action ARM64 runner instead of emulation

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -87,35 +87,40 @@ jobs:
             spotDL
 
   build-arm:
-    runs-on: ubuntu-latest
-    name: Build on ubuntu-latest aarch64
+    runs-on: ubuntu-24.04-arm64
+    name: Build on ubuntu-24.04-arm64
     steps:
       - uses: actions/checkout@v3
-      - uses: uraimo/run-on-arch-action@v2
-        name: Run commands
-        id: runcmd
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
         with:
-          arch: aarch64
-          distro: ubuntu_latest
+          python-version: "3.10"
 
-          # Mount the artifacts directory as /artifacts in the container
-          dockerRunArgs: |
-            --volume "${PWD}/:/spotdl"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+          enable-cache: true
 
-          # The shell to run commands with in the container
-          shell: /bin/sh
+      - name: Install dependencies
+        run: |
+          uv venv --python 3.10
+          uv sync
 
-          run: |
-            cd /spotdl
-            apt update
-            apt install python3-full python3-pip pipx -y
-            pipx ensurepath
-            pipx install uv
-            uv sync
-            rm -rf dist/
-            mkdir dist/
-            uv run python ./scripts/build.py
-            for file in dist/spotdl*; do cp "$file" "${file}-aarch64"; done
+      - name: Build
+        run: |
+          rm -rf dist/
+          mkdir dist/
+          uv run python ./scripts/build.py
+
+          for file in dist/spotdl*; do 
+            if [ -f "$file" ]; then
+              cp "$file" "${file}-aarch64"
+            fi
+          done
+
+          ls -la dist/
 
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
# Title
Utilise GH action ARM64 runner instead of emulation
## Description

https://github.blog/changelog/2024-06-24-github-actions-ubuntu-24-04-image-now-available-for-arm64-runners/



## Motivation and Context
python publish always failing on aarch64.

## How Has This Been Tested?
not yet...


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
