### PR TITLE
Notification of availability of YouTube formats added

### DIFF
--- a/spotdl/providers/audio/base.py
+++ b/spotdl/providers/audio/base.py
@@ -391,6 +391,13 @@ class AudioProvider:
             data = self.audio_handler.extract_info(url, download=download)
 
             if data:
+                # check for YouTube premium format Opus with bitrate up to 256 kbps
+                # see: https://gist.github.com/MartinEesmaa/2f4b261cb90a47e9c41ba115a011a4aa
+
+                for audio_format in data.get("formats", []):
+                    if audio_format.get("format_id") == "774":
+                        logger.info("YouTube Premium formats available!")
+
                 return data
         except Exception as exception:
             logger.debug(exception)


### PR DESCRIPTION
# Title
PR provides a simple implementation of the feature request https://github.com/spotDL/spotify-downloader/issues/2501.
The idea is to notify the user that YouTube Premium formats are available for download. 
It can work if:
1. Cookies of a YouTube Premium user are used for downloads 
2.  YouTube Premium formats are available for the requested video

## Description
The code uses yt-dlp data that already exists in the Base class of Audio providers:
````python
if data:
    # check for YouTube premium format Opus with bitrate up to 256 kbps
    # see: https://gist.github.com/MartinEesmaa/2f4b261cb90a47e9c41ba115a011a4aa

   for audio_format in data.get("formats", []):
        if audio_format.get("format_id") == "774":
             logger.info("YouTube Premium formats available!")
````

## Related Issue
The related issue with the feature request is https://github.com/spotDL/spotify-downloader/issues/2501.

## How Has This Been Tested?
Help with testing is required, as I don't have YouTube Premium.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-  New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed