### PR TITLE
feat: Use XDG config directory on Linux

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -238,9 +238,9 @@ add option `--web-use-output-dir`, which will make output directory follow `--ou
 ### Config file location
 
 The config file is located at `C:\Users\user\.spotdl\config.json`
-or `~/.spotdl/config.json` under linux
+or `~/config/spotdl/config.json` under Linux
 
-> Note: If you want to use XDG_DATA_HOME directory, run `mkdir $XDG_DATA_HOME/spotdl`, next time you run spotdl it will be automatically used.
+> Note: Prior to v4.4.3 the default Linux location was `~/.spotdl/config.json` which will be used if the new directory doesn't exist.
 
 ### Generate a config file
 

--- a/spotdl/utils/config.py
+++ b/spotdl/utils/config.py
@@ -47,9 +47,10 @@ class ConfigError(Exception):
     """
 
 
+# (Find the old get_spotdl_path function and REPLACE it with this new one)
 def get_spotdl_path() -> Path:
     """
-    Get the path to the spotdl folder.
+    Get the path to the spotdl folder, following XDG standards on Linux.
 
     ### Returns
     - The path to the spotdl folder.
@@ -58,16 +59,29 @@ def get_spotdl_path() -> Path:
     - If the spotdl directory does not exist, it will be created.
     """
 
-    # Check if os is linux
+    # For Linux systems, we follow the XDG Base Directory Specification
     if platform.system() == "Linux":
-        # if platform is linux, and XDG DATA HOME spotdl folder exists, use it
-        user_data_dir = Path(platformdirs.user_data_dir("spotdl", "spotDL"))
-        if user_data_dir.exists():
-            return user_data_dir
+        # Define the new, correct XDG config path (~/.config/spotdl)
+        xdg_config_path = Path.home() / ".config" / "spotdl"
 
-    spotdl_path = Path(os.path.expanduser("~"), ".spotdl")
-    if not spotdl_path.exists():
-        os.mkdir(spotdl_path)
+        # Define the old path (~/.spotdl) for backward compatibility
+        old_spotdl_path = Path.home() / ".spotdl"
+
+        # Scenario 1: The user already has the new XDG config folder. Use it.
+        if xdg_config_path.exists():
+            return xdg_config_path
+
+        # Scenario 2: The user is an existing user with only the old folder. Use the old one.
+        if old_spotdl_path.exists():
+            return old_spotdl_path
+
+        # Scenario 3: The user is brand new. Create and use the new XDG path.
+        os.makedirs(xdg_config_path, exist_ok=True)
+        return xdg_config_path
+
+    # For non-Linux systems (like Windows), use the default ~/.spotdl path
+    spotdl_path = Path.home() / ".spotdl"
+    os.makedirs(spotdl_path, exist_ok=True)
 
     return spotdl_path
 

--- a/spotdl/utils/config.py
+++ b/spotdl/utils/config.py
@@ -47,7 +47,6 @@ class ConfigError(Exception):
     """
 
 
-# (Find the old get_spotdl_path function and REPLACE it with this new one)
 def get_spotdl_path() -> Path:
     """
     Get the path to the spotdl folder, following XDG standards on Linux.

--- a/spotdl/utils/config.py
+++ b/spotdl/utils/config.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Any, Dict, Tuple, Union
 
 
-
 from spotdl.types.options import (
     DownloaderOptions,
     SpotDLOptions,

--- a/spotdl/utils/config.py
+++ b/spotdl/utils/config.py
@@ -12,7 +12,7 @@ from argparse import Namespace
 from pathlib import Path
 from typing import Any, Dict, Tuple, Union
 
-import platformdirs
+
 
 from spotdl.types.options import (
     DownloaderOptions,

--- a/spotdl/utils/config.py
+++ b/spotdl/utils/config.py
@@ -12,7 +12,6 @@ from argparse import Namespace
 from pathlib import Path
 from typing import Any, Dict, Tuple, Union
 
-
 from spotdl.types.options import (
     DownloaderOptions,
     SpotDLOptions,

--- a/spotdl/utils/config.py
+++ b/spotdl/utils/config.py
@@ -57,7 +57,6 @@ def get_spotdl_path() -> Path:
     - The path to the spotdl folder.
 
     ### Notes
-    - If the spotdl directory does not exist, it will be created.
     """
 
     # For Linux systems, we follow the XDG Base Directory Specification

--- a/spotdl/utils/config.py
+++ b/spotdl/utils/config.py
@@ -50,6 +50,8 @@ class ConfigError(Exception):
 def get_spotdl_path() -> Path:
     """
     Get the path to the spotdl folder, following XDG standards on Linux.
+    ~/.config/spotdl/ is used if it exists, else ~/.spotdl if it exists.
+    If the spotdl directory does not exist, it will be created
 
     ### Returns
     - The path to the spotdl folder.


### PR DESCRIPTION


## Description
This change updates the application to use the standard XDG config directory (`~/.config/spotdl`) on Linux, while maintaining backward compatibility for existing users.

## Related Issue
Closes #2387

## Motivation and Context
This helps de-clutter the user's home folder on Linux and follows standard conventions, as requested in issue #2387.

## How Has This Been Tested?
I have manually tested the following scenarios:
1. New user: Verified the new `~/.config/spotdl` directory is created.
2. Existing user (legacy): Verified the old `~/.spotdl` directory is used if present.
3. Existing user (modern): Verified the new `~/.config/spotdl` is prioritized if both directories exist.
## Screenshots (if appropriate)

## Types of Changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
