### PR TITLE
Return original user-friendly URL from the "spotdl url" command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ For a list of all **options** use ```spotdl -h```
 
 - `web`: Starts a web interface instead of using the command line. However, it has limited features and only supports downloading single songs.
 
-- `url`: Get direct download link for each song from the query.
+- `url`: Get user-friendly URL for each song from the query.
     - Usage:
         `spotdl url [query]`
 

--- a/spotdl/console/url.py
+++ b/spotdl/console/url.py
@@ -45,7 +45,7 @@ def url(
                 return None
 
             audio_provider = downloader.audio_providers[0]
-            download_url = audio_provider.get_download_metadata(data)["url"]
+            download_url = audio_provider.get_download_metadata(data)["original_url"]
 
             print(download_url)
         except Exception as exception:


### PR DESCRIPTION
# Title
Return original user-friendly URL from the "spotdl url" command.

## Description
Previously, the "spotdl url" command would return the direct download link. Now, it returns the user-friendly URL requested in the following issue. This took me some time to find a fix for, but it is a simple fix. I just had to retrieve the "original_url" element instead of the "url" element.

## Related Issue
Fixes #2401 

## Motivation and Context
Contributing during Hacktoberfest. Thought this project was neat and this issue would be good to start with.

## How Has This Been Tested?
I built the package and installed it. Can confirm that it works properly now and does not affect other functions.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
