### PR TITLE
Fix YouTube not downloading

### DIFF
--- a/spotdl/providers/audio/base.py
+++ b/spotdl/providers/audio/base.py
@@ -98,7 +98,7 @@ class AudioProvider:
         elif self.output_format == "opus":
             ytdl_format = "bestaudio[ext=webm]/bestaudio/best"
         else:
-            ytdl_format = "bestaudio"
+            ytdl_format = "bestaudio/best"
 
         yt_dlp_options = {
             "format": ytdl_format,


### PR DESCRIPTION
Fixes #2555

# Title
Fixes certain YouTube videos not downloading

## Description
Adds "/best" by default. Courtesy of [[gamer191](https://github.com/gamer191)](https://github.com/spotDL/spotify-downloader/issues/2547#issuecomment-3456370475)

## Related Issue
Fixes #2555

## Motivation and Context
Some YouTube videos do not download and error out.

## How Has This Been Tested?
I was able to download videos I couldn't before.

## Screenshots (if appropriate)
N/A

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [] My change requires a change to the documentation
- [] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [] I have added tests to cover my changes
- [] All new and existing tests passed
