### PR TITLE
fix: add exponential backoff to spotify download

### DIFF
--- a/spotdl/utils/spotify.py
+++ b/spotdl/utils/spotify.py
@@ -17,6 +17,7 @@ import requests
 from spotipy import Spotify
 from spotipy.cache_handler import CacheFileHandler, MemoryCacheHandler
 from spotipy.oauth2 import SpotifyClientCredentials, SpotifyOAuth
+from spotipy.exceptions import SpotifyException
 
 from spotdl.utils.config import get_cache_path, get_spotify_cache_path
 
@@ -194,7 +195,7 @@ class SpotifyClient(Spotify, metaclass=Singleton):
         while response is None:
             try:
                 response = self._internal_call("GET", url, payload, kwargs)
-            except (requests.exceptions.Timeout, requests.ConnectionError) as exc:
+            except (requests.exceptions.Timeout, requests.ConnectionError, SpotifyException) as exc:
                 retries -= 1
                 if retries <= 0:
                     raise exc

--- a/spotdl/utils/spotify.py
+++ b/spotdl/utils/spotify.py
@@ -199,7 +199,7 @@ class SpotifyClient(Spotify, metaclass=Singleton):
                 if retries <= 0:
                     raise exc
             # Exponential backoff after retry (0.2s -> 0.4s -> 0.8s -> ...)
-            time.sleep(0.2 * (2**(self.max_retries - retries)))
+            time.sleep(0.2 * (2 ** (self.max_retries - retries)))
 
         if use_cache and cache_key is not None:
             self.cache[cache_key] = response

--- a/spotdl/utils/spotify.py
+++ b/spotdl/utils/spotify.py
@@ -10,6 +10,7 @@ spotify.Spotify.init(client_id, client_secret)
 
 import json
 import logging
+import time
 from typing import Dict, Optional
 
 import requests
@@ -197,6 +198,8 @@ class SpotifyClient(Spotify, metaclass=Singleton):
                 retries -= 1
                 if retries <= 0:
                     raise exc
+            # Exponential backoff after retry (0.2s -> 0.4s -> 0.8s -> ...)
+            time.sleep(0.2 * (2**(self.max_retries - retries)))
 
         if use_cache and cache_key is not None:
             self.cache[cache_key] = response

--- a/spotdl/utils/spotify.py
+++ b/spotdl/utils/spotify.py
@@ -16,8 +16,8 @@ from typing import Dict, Optional
 import requests
 from spotipy import Spotify
 from spotipy.cache_handler import CacheFileHandler, MemoryCacheHandler
-from spotipy.oauth2 import SpotifyClientCredentials, SpotifyOAuth
 from spotipy.exceptions import SpotifyException
+from spotipy.oauth2 import SpotifyClientCredentials, SpotifyOAuth
 
 from spotdl.utils.config import get_cache_path, get_spotify_cache_path
 

--- a/spotdl/utils/spotify.py
+++ b/spotdl/utils/spotify.py
@@ -198,8 +198,8 @@ class SpotifyClient(Spotify, metaclass=Singleton):
                 retries -= 1
                 if retries <= 0:
                     raise exc
-            # Exponential backoff after retry (1s -> 2s -> 4s -> ...)
-            time.sleep(2 ** (self.max_retries - retries))
+                # Exponential backoff after retry (1s -> 2s -> 4s -> ...)
+                time.sleep(2 ** (self.max_retries - retries))
 
         if use_cache and cache_key is not None:
             self.cache[cache_key] = response

--- a/spotdl/utils/spotify.py
+++ b/spotdl/utils/spotify.py
@@ -198,8 +198,8 @@ class SpotifyClient(Spotify, metaclass=Singleton):
                 retries -= 1
                 if retries <= 0:
                     raise exc
-            # Exponential backoff after retry (0.2s -> 0.4s -> 0.8s -> ...)
-            time.sleep(0.2 * (2 ** (self.max_retries - retries)))
+            # Exponential backoff after retry (1s -> 2s -> 4s -> ...)
+            time.sleep(2 ** (self.max_retries - retries))
 
         if use_cache and cache_key is not None:
             self.cache[cache_key] = response

--- a/spotdl/utils/spotify.py
+++ b/spotdl/utils/spotify.py
@@ -195,7 +195,11 @@ class SpotifyClient(Spotify, metaclass=Singleton):
         while response is None:
             try:
                 response = self._internal_call("GET", url, payload, kwargs)
-            except (requests.exceptions.Timeout, requests.ConnectionError, SpotifyException) as exc:
+            except (
+                requests.exceptions.Timeout,
+                requests.ConnectionError,
+                SpotifyException,
+            ) as exc:
                 retries -= 1
                 if retries <= 0:
                     raise exc


### PR DESCRIPTION
# Adding exponential backoff for spotify client retries

## Description
Adding exponential backoff for spotify client retries


## Related Issue
#2461 

## Motivation and Context
Currently we do not wait at all between retries, leading to repeated 429 errors, reaching max retries, and risking ip bans.
Adding this exponential backoff will make sure we give time for the ratelimit to recover and avoid 429 errors.

## How Has This Been Tested?
I have faced constant `Max Retries, reason: too many 429 error responses`  errors when downloading a large playlist. Adding these 2 simple lines let me download the whole playlist in one go without any issues.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
