### PR TITLE
feature: Add support for Exportify csv format & make operation option mandatory

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -77,16 +77,21 @@ follow these instructions
 
 ## Usage
 
+There are different **operations** spotDL can perform. For example `download`, which simply downloads the songs from YouTube and embeds metadata.
+
+The **query** for spotDL is usually a list of Spotify URLs, but for some operations like **sync**, only a single link or file is required.
+For a list of all **options** use ```spotdl -h```
+
 Using SpotDL without options:
 
 ```sh
-spotdl [urls]
+spotdl [operation] [urls]
 ```
 
 You can run _spotDL_ as a package if running it as a script doesn't work:
 
 ```sh
-python -m spotdl [urls]
+python -m spotdl [operation] [urls]
 ```
 
 General usage:
@@ -94,11 +99,6 @@ General usage:
 ```sh
 spotdl [operation] [options] QUERY
 ```
-
-There are different **operations** spotDL can perform. The _default_ is `download`, which simply downloads the songs from YouTube and embeds metadata.
-
-The **query** for spotDL is usually a list of Spotify URLs, but for some operations like **sync**, only a single link or file is required.
-For a list of all **options** use ```spotdl -h```
 
 ### Refer to [Usage](usage.md) for more info.
 

--- a/spotdl/console/entry_point.py
+++ b/spotdl/console/entry_point.py
@@ -2,12 +2,15 @@
 Module that holds the entry point for the console.
 """
 
+import csv
 import cProfile
 import logging
 import pstats
 import signal
 import sys
 import time
+
+from pathlib import Path
 
 from spotdl.console.download import download
 from spotdl.console.meta import meta
@@ -137,6 +140,35 @@ def entry_point():
             "You must be logged in to use the saved query. "
             "Log in by adding the --user-auth flag"
         )
+
+    # Check if we expect extra songs from Exportify
+    # csv and append them to the query
+    if arguments.load_exportify:
+
+        csv_path = Path(arguments.load_exportify)
+
+        if not csv_path.exists():
+            raise FileNotFoundError(
+                "Exportify csv not found." "Please specify an existing file path."
+            )
+
+        with open(csv_path, "r", encoding="utf-8") as csv_file:
+            reader = csv.reader(csv_file)
+
+            # skip the first row
+            next(reader, None)
+
+            for row in reader:
+                if row:
+
+                    # first column is the track URI, which
+                    # is formatted as spotify:track:[track_id]
+                    # https://github.com/watsonbox/exportify/blob/master/README.md#export-format
+                    # here we only want the track id part
+                    track_id = row[0].split(":")[-1]
+                    track_url = f"https://open.spotify.com/track/{track_id}"
+
+                    arguments.query.append(track_url)
 
     # Initialize the downloader
     # for download, load and preload operations

--- a/spotdl/utils/arguments.py
+++ b/spotdl/utils/arguments.py
@@ -50,9 +50,6 @@ def parse_main_options(parser: _ArgumentGroup):
     operation = parser.add_argument(
         "operation",
         choices=OPERATIONS,
-        default="download",
-        const="download",
-        nargs="?",
         help=(
             "N|The operation to perform.\n"
             "download: Download the songs to the disk and embed metadata.\n"

--- a/spotdl/utils/arguments.py
+++ b/spotdl/utils/arguments.py
@@ -67,7 +67,7 @@ def parse_main_options(parser: _ArgumentGroup):
     # Add query argument
     query = parser.add_argument(
         "query",
-        nargs="+",
+        nargs="*",
         type=str,
         help=(
             "N|Spotify/YouTube URL for a song/playlist/album/artist/etc. to download.\n\n"
@@ -175,6 +175,12 @@ def parse_main_options(parser: _ArgumentGroup):
         action="store_const",
         const=True,
         help="Use only verified results. (Not all providers support this)",
+    )
+
+    # Add songs from Exportify csv to the query
+    parser.add_argument(
+        "--load-exportify",
+        help="Load songs from an Exportify csv. (Can be used together with normal query)",
     )
 
 
@@ -873,4 +879,12 @@ def parse_arguments() -> Namespace:
     parser = create_parser()
 
     # Parse arguments
-    return parser.parse_args()
+    arguments = parser.parse_args()
+
+    # ensure at least one of the two (query or exportify list) are given
+    if not any((arguments.query, arguments.load_exportify)):
+        parser.error(
+            "one of the following arguments are required: query, --load-exportify"
+        )
+
+    return arguments


### PR DESCRIPTION
# feature: Add support for Exportify csv format & make operation option mandatory
Implements the flag --load-exportify. It can now be used to load songs directly from the Exportify generated csv.
The format of it can be found [here](https://github.com/watsonbox/exportify/blob/master/README.md#export-format).

Also when I started using spotdl, I found it really confusing that the operation option isn't actually required, but when adding multiple songs to the query it tries to take the first one as operation, so you have to use it again. Also, I needed to allow zero arguments as query, in case of --load-exportify being used,  and handle exceptions manually, which makes this behavior even worse, so I thought it would be better to just make setting the operation mandatory. 

With this being a pretty intrusive change please let me know how you feel about it, or if there is a better way of doing this. 

I think it's very useful for people who don't know how to convert their playlists themself.

## Related Issue
#2586 

## How Has This Been Tested?
works fine on:
Python 3.13.11
6.18.5-arch1-1

pylint score 10.0

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
