### PR TITLE
Fix/song from url missing spotify fields

### DIFF
--- a/spotdl/types/song.py
+++ b/spotdl/types/song.py
@@ -114,9 +114,9 @@ class Song:
                 if raw_album_meta["copyrights"]
                 else None
             ),
-            genres=raw_album_meta["genres"] + raw_artist_meta["genres"],
+            genres=(raw_album_meta.get("genres") or []) + (raw_artist_meta.get("genres") or []),
             disc_number=raw_track_meta["disc_number"],
-            disc_count=int(raw_album_meta["tracks"]["items"][-1]["disc_number"]),
+            disc_count=int(raw_album_meta.get("tracks", {}).get("items", [{}])[-1].get("disc_number", raw_track_meta["disc_number"])),
             duration=int(raw_track_meta["duration_ms"] / 1000),
             year=int(raw_album_meta["release_date"][:4]),
             date=raw_album_meta["release_date"],
@@ -125,14 +125,14 @@ class Song:
             isrc=raw_track_meta.get("external_ids", {}).get("isrc"),
             song_id=raw_track_meta["id"],
             explicit=raw_track_meta["explicit"],
-            publisher=raw_album_meta["label"],
+            publisher=raw_album_meta.get("label", ""),
             url=raw_track_meta["external_urls"]["spotify"],
-            popularity=raw_track_meta["popularity"],
+            popularity=raw_track_meta.get("popularity"),
             cover_url=(
                 max(raw_album_meta["images"], key=lambda i: i["width"] * i["height"])[
                     "url"
                 ]
-                if raw_album_meta["images"]
+                if raw_album_meta.get("images")
                 else None
             ),
         )

--- a/tests/types/test_song.py
+++ b/tests/types/test_song.py
@@ -2,6 +2,7 @@ import pytest
 
 from spotdl.types.album import Album
 from spotdl.types.song import Song
+from spotdl.utils.spotify import SpotifyClient
 
 
 def test_song_init():
@@ -201,6 +202,57 @@ def test_song_from_data_dump_wrong_type():
 
     with pytest.raises(TypeError):
         Song.from_data_dump(1)  # type: ignore
+
+
+def test_song_from_url_missing_optional_spotify_fields(monkeypatch):
+    """
+    Song.from_url() should tolerate partial Spotify payloads.
+    """
+
+    class DummySpotifyClient:
+        def track(self, _url):
+            return {
+                "id": "track-id",
+                "name": "Test Track",
+                "duration_ms": 204000,
+                "disc_number": 1,
+                "track_number": 1,
+                "explicit": False,
+                "popularity": 17,
+                "external_urls": {"spotify": "https://open.spotify.com/track/track-id"},
+                "external_ids": {"isrc": "TEST12345678"},
+                "artists": [{"id": "artist-id", "name": "Test Artist"}],
+                "album": {"id": "album-id"},
+            }
+
+        def artist(self, _artist_id):
+            return {
+                "id": "artist-id",
+                "name": "Test Artist",
+            }
+
+        def album(self, _album_id):
+            return {
+                "id": "album-id",
+                "name": "Test Album",
+                "artists": [{"name": "Test Artist"}],
+                "release_date": "2024-01-02",
+                "total_tracks": 1,
+                "tracks": {"items": [{"disc_number": 1}]},
+                "copyrights": [],
+            }
+
+    monkeypatch.setattr(SpotifyClient, "_instance", DummySpotifyClient())
+
+    song = Song.from_url("https://open.spotify.com/track/track-id")
+
+    assert song.name == "Test Track"
+    assert song.artists == ["Test Artist"]
+    assert song.album_name == "Test Album"
+    assert song.genres == []
+    assert song.publisher == ""
+    assert song.cover_url is None
+    assert song.popularity == 17
 
 
 def test_song_from_dict():


### PR DESCRIPTION
# Title
  Handle missing optional Spotify metadata in `Song.from_url`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change makes `Song.from_url()` more defensive when Spotify returns partial
  metadata for a track.

  The current implementation assumes that fields such as `genres`, `label`, `images`,
  and `popularity` are always present in the Spotify API response. In practice, some
  valid tracks omit one or more of these optional fields, which causes `spotdl` to raise
  `KeyError` and abort.

  This patch replaces those direct dictionary accesses with safe defaults so valid
  tracks can still be processed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
 Related to the open issue reporting a `KeyError` in `Song.from_url()` when Spotify
  metadata omits fields like `genres`.
  https://github.com/spotDL/spotify-downloader/issues/2619

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
  Spotify metadata responses are not always complete for every track.

  Because `Song.from_url()` treats several optional fields as required, `spotdl` can
  fail on otherwise valid Spotify track URLs. This patch makes the parsing more robust
  and prevents crashes caused by missing optional metadata.
## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
