### PR TITLE
fix(song): handle missing genres in metadata

### DIFF
--- a/spotdl/types/song.py
+++ b/spotdl/types/song.py
@@ -114,7 +114,7 @@ class Song:
                 if raw_album_meta["copyrights"]
                 else None
             ),
-            genres=raw_album_meta["genres"] + raw_artist_meta["genres"],
+            genres=raw_album_meta.get("genres", []) + raw_artist_meta.get("genres", []),
             disc_number=raw_track_meta["disc_number"],
             disc_count=int(raw_album_meta["tracks"]["items"][-1]["disc_number"]),
             duration=int(raw_track_meta["duration_ms"] / 1000),


### PR DESCRIPTION
## Issue
Fixes #2619

## Problem
When the Spotify API doesn't return `genres` for albums or artists, spotDL crashes with `KeyError: 'genres'`.

This happens because the code directly accesses `raw_album_meta["genres"]` and `raw_artist_meta["genres"]` without checking if these keys exist.

## Solution
Use `.get("genres", [])` instead of direct key access to safely handle cases where genres data is missing from the API response.

## Changes
- Line 117 in `spotdl/types/song.py`: Changed `raw_album_meta["genres"] + raw_artist_meta["genres"]` to `raw_album_meta.get("genres", []) + raw_artist_meta.get("genres", [])`

This follows the same pattern used elsewhere in the codebase (e.g., line 111 for `album_type`, line 125 for `isrc`).