### PR TITLE
fix: Spotify API 2026 - playlist 403, genres/label KeyErrors, OAuth s…

### DIFF
--- a/spotdl/types/playlist.py
+++ b/spotdl/types/playlist.py
@@ -45,7 +45,17 @@ class Playlist(SongList):
 
         spotify_client = SpotifyClient()
 
-        playlist = spotify_client.playlist(url)
+        market = None
+        try:
+            profile = spotify_client.me()
+            if profile:
+                market = profile.get("country")
+        except Exception:  # noqa: BLE001
+            pass
+
+        playlist = spotify_client.playlist(
+            url, additional_types=("track",), market=market
+        )
         if playlist is None:
             raise PlaylistError("Invalid playlist URL.")
 
@@ -69,24 +79,32 @@ class Playlist(SongList):
             ),
         }
 
-        playlist_response = spotify_client.playlist_items(url)
-        if playlist_response is None:
+        page = playlist.get("tracks")
+        if page is None:
+            page = playlist.get("items")
+        if not isinstance(page, dict):
             raise PlaylistError(f"Wrong playlist id: {url}")
 
-        # Get all tracks from playlist
-        tracks = playlist_response["items"]
-        while playlist_response["next"]:
-            playlist_response = spotify_client.next(playlist_response)
+        def _row_track(row: Dict[str, Any]) -> Dict[str, Any]:
+            t = row.get("track")
+            if t is None:
+                item = row.get("item")
+                if isinstance(item, dict) and item.get("type") == "track":
+                    t = item
+            return {"track": t}
 
-            # Failed to get response, break the loop
-            if playlist_response is None:
+        raw_tracks = [_row_track(r) for r in page.get("items", [])]
+        while page.get("next"):
+            try:
+                page = spotify_client.next(page)
+            except Exception as exc:  # noqa: BLE001
+                raise PlaylistError("Could not fetch next page of tracks.") from exc
+            if page is None:
                 break
-
-            # Add tracks to the list
-            tracks.extend(playlist_response["items"])
+            raw_tracks.extend(_row_track(r) for r in page.get("items", []))
 
         songs = []
-        for track_no, track in enumerate(tracks):
+        for track_no, track in enumerate(raw_tracks):
             if not isinstance(track, dict) or track.get("track") is None:
                 continue
 

--- a/spotdl/types/song.py
+++ b/spotdl/types/song.py
@@ -114,7 +114,7 @@ class Song:
                 if raw_album_meta["copyrights"]
                 else None
             ),
-            genres=raw_album_meta["genres"] + raw_artist_meta["genres"],
+            genres=(raw_album_meta.get("genres") or []) + (raw_artist_meta.get("genres") or []),
             disc_number=raw_track_meta["disc_number"],
             disc_count=int(raw_album_meta["tracks"]["items"][-1]["disc_number"]),
             duration=int(raw_track_meta["duration_ms"] / 1000),
@@ -125,9 +125,9 @@ class Song:
             isrc=raw_track_meta.get("external_ids", {}).get("isrc"),
             song_id=raw_track_meta["id"],
             explicit=raw_track_meta["explicit"],
-            publisher=raw_album_meta["label"],
+            publisher=raw_album_meta.get("label") or "",
             url=raw_track_meta["external_urls"]["spotify"],
-            popularity=raw_track_meta["popularity"],
+            popularity=raw_track_meta.get("popularity", 0),
             cover_url=(
                 max(raw_album_meta["images"], key=lambda i: i["width"] * i["height"])[
                     "url"

--- a/spotdl/utils/spotify.py
+++ b/spotdl/utils/spotify.py
@@ -100,9 +100,12 @@ class Singleton(type):
         )
         # Use SpotifyOAuth as auth manager
         if user_auth:
-            redirect_uri = os.getenv(
-                "SPOTIPY_REDIRECT_URI", "https://kichelle.free.beeceptor.com"
-            )
+            redirect_uri = os.getenv("SPOTIPY_REDIRECT_URI")
+            if not redirect_uri:
+                raise SpotifyError(
+                    "SPOTIPY_REDIRECT_URI environment variable is not set. "
+                    "Please set it to your application's redirect URI."
+                )
             credential_manager = SpotifyOAuth(
                 client_id=client_id,
                 client_secret=client_secret,

--- a/spotdl/utils/spotify.py
+++ b/spotdl/utils/spotify.py
@@ -10,6 +10,7 @@ spotify.Spotify.init(client_id, client_secret)
 
 import json
 import logging
+import os
 from typing import Dict, Optional
 
 import requests
@@ -99,11 +100,18 @@ class Singleton(type):
         )
         # Use SpotifyOAuth as auth manager
         if user_auth:
+            redirect_uri = os.getenv(
+                "SPOTIPY_REDIRECT_URI", "https://kichelle.free.beeceptor.com"
+            )
             credential_manager = SpotifyOAuth(
                 client_id=client_id,
                 client_secret=client_secret,
-                redirect_uri="http://127.0.0.1:9900/",
-                scope="user-library-read,user-follow-read,playlist-read-private",
+                redirect_uri=redirect_uri,
+                scope=(
+                    "user-library-read,user-follow-read,"
+                    "playlist-read-private,playlist-read-collaborative,"
+                    "user-read-private"
+                ),
                 cache_handler=cache_handler,
                 open_browser=not headless,
             )


### PR DESCRIPTION
## Fix: 403 Forbidden on playlist tracks + auth issues (spotdl 4.4.3, Spotify API 2025/2026)

**Environment:** macOS, spotdl 4.4.3, spotipy, Python 3.12

---

### Problem 1: `GET /v1/playlists/{id}/tracks` returns 403

Spotify's `/tracks` endpoint now returns 403 for apps in Development Mode, even with a valid user OAuth token. However, `GET /v1/playlists/{id}` still works and returns track data under `items` (newer response shape where each row uses `item` instead of `track`).

**Fix — patch `spotdl/types/playlist.py`:**

Replace the `playlist_items()` call with `playlist()` and read tracks from the embedded page:

```python
market = None
try:
    profile = spotify_client.me()
    if profile:
        market = profile.get("country")
except Exception:
    pass

playlist = spotify_client.playlist(
    url, additional_types=("track",), market=market
)

page = playlist.get("tracks")
if page is None:
    page = playlist.get("items")

def _row_track(row):
    t = row.get("track")
    if t is None:
        item = row.get("item")
        if isinstance(item, dict) and item.get("type") == "track":
            t = item
    return {"track": t}

raw_tracks = [_row_track(r) for r in page.get("items", [])]
while page.get("next"):
    page = spotify_client.next(page)
    if page is None:
        break
    raw_tracks.extend(_row_track(r) for r in page.get("items", []))
```

---

### Problem 2: `genres`, `label`, `popularity` KeyErrors during song enrichment

Spotify's album and artist API responses sometimes omit these fields for certain tracks, causing `Song.from_url()` to crash with a `KeyError`.

**Fix — patch `spotdl/types/song.py`:**

```python
# before
genres=raw_album_meta["genres"] + raw_artist_meta["genres"],
publisher=raw_album_meta["label"],
popularity=raw_track_meta["popularity"],

# after
genres=(raw_album_meta.get("genres") or []) + (raw_artist_meta.get("genres") or []),
publisher=raw_album_meta.get("label") or "",
popularity=raw_track_meta.get("popularity", 0),
```

---

### Problem 3: OAuth scopes insufficient + hardcoded redirect URI

The default scopes (`user-library-read`, `user-follow-read`) don't include playlist scopes. The redirect URI is hardcoded to `http://127.0.0.1:9900/` which may not work in all environments.

**Fix — patch `spotdl/utils/spotify.py`:**

```python
import os  # add to imports

# in the user_auth block:
redirect_uri = os.getenv("SPOTIPY_REDIRECT_URI", "http://127.0.0.1:9900/")
credential_manager = SpotifyOAuth(
    client_id=client_id,
    client_secret=client_secret,
    redirect_uri=redirect_uri,
    scope=(
        "user-library-read,user-follow-read,"
        "playlist-read-private,playlist-read-collaborative,"
        "user-read-private"
    ),
    cache_handler=cache_handler,
    open_browser=not headless,
)
```

If you can't use the loopback server (port 9900 blocked, running headless, etc.), set `SPOTIPY_REDIRECT_URI` to any HTTPS URL registered on your Spotify app, then use `--headless` and paste the full redirect URL when prompted.

---

### Problem 4: yt-dlp too old — `Precondition check failed / Signature extraction failed`

Downloads stuck at 0% because yt-dlp 2023.x can no longer decrypt YouTube streaming URLs. spotdl 4.4.3 pins `yt-dlp<2024.0.0` in its requirements but the pin needs to be overridden.

**Fix:**

```bash
pip install -U yt-dlp  # ignore the version conflict warning from spotdl
```

---

### Spotify API rate limits

Development Mode apps hit a daily quota (~600–800 calls) since spotdl calls `track()`, `album()`, and `artist()` per song (~3 calls each). On large playlists (100+ tracks) you will get:

```
Your application has reached a rate/request limit. Retry will occur after: 84333 s
```

This is a ~24h rolling window reset. Mitigations:

- Use `--threads 1` to reduce burst rate
- Use `--archive /path/to/archive.txt` (or set it in `~/.spotdl/config.json`) so re-runs skip already-downloaded tracks entirely and avoid redundant API calls

---

Hope this saves someone a few hours!