### PR TITLE
fix: handle Spotify February 2026 API breaking changes for playlist i…

### DIFF
--- a/spotdl/types/playlist.py
+++ b/spotdl/types/playlist.py
@@ -87,10 +87,12 @@ class Playlist(SongList):
 
         songs = []
         for track_no, track in enumerate(tracks):
-            if not isinstance(track, dict) or track.get("track") is None:
+            if not isinstance(track, dict):
                 continue
 
-            track_meta = track["track"]
+            track_meta = track.get("item") or track.get("track")
+            if track_meta is None:
+                continue
 
             if track_meta.get("is_local") or track_meta.get("type") != "track":
                 logger.warning(

--- a/spotdl/types/song.py
+++ b/spotdl/types/song.py
@@ -127,7 +127,7 @@ class Song:
             explicit=raw_track_meta["explicit"],
             publisher=raw_album_meta["label"],
             url=raw_track_meta["external_urls"]["spotify"],
-            popularity=raw_track_meta["popularity"],
+            popularity=raw_track_meta.get("popularity"),
             cover_url=(
                 max(raw_album_meta["images"], key=lambda i: i["width"] * i["height"])[
                     "url"

--- a/spotdl/types/song.py
+++ b/spotdl/types/song.py
@@ -114,7 +114,7 @@ class Song:
                 if raw_album_meta["copyrights"]
                 else None
             ),
-            genres=raw_album_meta["genres"] + raw_artist_meta["genres"],
+            genres=(raw_album_meta.get("genres") or []) + (raw_artist_meta.get("genres") or []),
             disc_number=raw_track_meta["disc_number"],
             disc_count=int(raw_album_meta["tracks"]["items"][-1]["disc_number"]),
             duration=int(raw_track_meta["duration_ms"] / 1000),

--- a/tests/types/test_playlist.py
+++ b/tests/types/test_playlist.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from spotdl.types.playlist import Playlist
@@ -68,6 +70,89 @@ def test_playlist_from_string():
     assert playlist.name == "This Is Gorillaz"
     assert playlist.url == "http://open.spotify.com/playlist/37i9dQZF1DZ06evO25rXbO"
     assert len(playlist.urls) > 1
+
+
+def _make_track_item(field_name="track"):
+    """Helper to create a playlist item using the given field name for track metadata."""
+    return {
+        field_name: {
+            "id": "abc123",
+            "name": "Test Song",
+            "artists": [{"name": "Test Artist"}],
+            "album": {
+                "id": "album123",
+                "name": "Test Album",
+                "artists": [{"name": "Test Artist"}],
+                "album_type": "album",
+                "release_date": "2024-01-01",
+                "total_tracks": 1,
+                "images": [{"url": "https://example.com/img.jpg", "width": 300, "height": 300}],
+            },
+            "type": "track",
+            "is_local": False,
+            "disc_number": 1,
+            "track_number": 1,
+            "duration_ms": 180000,
+            "explicit": False,
+            "external_urls": {"spotify": "https://open.spotify.com/track/abc123"},
+            "external_ids": {"isrc": "USTEST0000001"},
+        }
+    }
+
+
+def _mock_spotify_client(items):
+    """Create a mock SpotifyClient that returns the given playlist items."""
+    mock_client = MagicMock()
+    mock_client.playlist.return_value = {
+        "name": "Mock Playlist",
+        "description": "desc",
+        "external_urls": {"spotify": "https://open.spotify.com/playlist/mock"},
+        "owner": {"display_name": "Owner"},
+        "images": [{"url": "https://example.com/cover.jpg", "width": 300, "height": 300}],
+    }
+    mock_client.playlist_items.return_value = {
+        "items": items,
+        "next": None,
+    }
+    return mock_client
+
+
+@patch("spotdl.types.playlist.SpotifyClient")
+def test_playlist_parses_new_item_field(mock_sc_cls):
+    """
+    Spotify's Feb 2026 API returns 'item' instead of 'track' in playlist responses.
+    """
+    mock_sc_cls.return_value = _mock_spotify_client([_make_track_item("item")])
+
+    metadata, songs = Playlist.get_metadata("https://open.spotify.com/playlist/mock")
+
+    assert len(songs) == 1
+    assert songs[0].name == "Test Song"
+
+
+@patch("spotdl.types.playlist.SpotifyClient")
+def test_playlist_parses_legacy_track_field(mock_sc_cls):
+    """
+    Backward compatibility: the old 'track' field should still work.
+    """
+    mock_sc_cls.return_value = _mock_spotify_client([_make_track_item("track")])
+
+    metadata, songs = Playlist.get_metadata("https://open.spotify.com/playlist/mock")
+
+    assert len(songs) == 1
+    assert songs[0].name == "Test Song"
+
+
+@patch("spotdl.types.playlist.SpotifyClient")
+def test_playlist_skips_item_with_neither_field(mock_sc_cls):
+    """
+    Items with neither 'item' nor 'track' should be skipped.
+    """
+    mock_sc_cls.return_value = _mock_spotify_client([{"other_key": {}}])
+
+    metadata, songs = Playlist.get_metadata("https://open.spotify.com/playlist/mock")
+
+    assert len(songs) == 0
 
 
 @pytest.mark.vcr()

--- a/tests/types/test_song.py
+++ b/tests/types/test_song.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from spotdl.types.album import Album
@@ -257,3 +259,77 @@ def test_song_from_dict():
     )
     assert song.explicit == False
     assert song.popularity == 0
+
+
+def _make_raw_track_meta():
+    return {
+        "name": "Test Song",
+        "artists": [{"name": "Test Artist", "id": "artist123"}],
+        "album": {"id": "album123"},
+        "disc_number": 1,
+        "track_number": 1,
+        "duration_ms": 180000,
+        "explicit": False,
+        "external_urls": {"spotify": "https://open.spotify.com/track/abc123"},
+        "external_ids": {"isrc": "USTEST0000001"},
+        "id": "abc123",
+        "popularity": 50,
+    }
+
+
+def _make_raw_album_meta(genres=None):
+    meta = {
+        "name": "Test Album",
+        "artists": [{"name": "Test Artist"}],
+        "album_type": "album",
+        "copyrights": [{"text": "(c) 2024"}],
+        "release_date": "2024-01-01",
+        "total_tracks": 1,
+        "tracks": {"items": [{"disc_number": 1}]},
+        "label": "Test Label",
+        "images": [{"url": "https://example.com/img.jpg", "width": 300, "height": 300}],
+    }
+    if genres is not None:
+        meta["genres"] = genres
+    return meta
+
+
+def _make_raw_artist_meta(genres=None):
+    meta = {"name": "Test Artist"}
+    if genres is not None:
+        meta["genres"] = genres
+    return meta
+
+
+@patch("spotdl.types.song.SpotifyClient")
+def test_song_from_url_missing_genres(mock_sc_cls):
+    """
+    Spotify's Feb 2026 API removed 'genres' from album/artist metadata.
+    Song.from_url should handle missing genres gracefully.
+    """
+    mock_client = MagicMock()
+    mock_client.track.return_value = _make_raw_track_meta()
+    mock_client.artist.return_value = _make_raw_artist_meta(genres=None)
+    mock_client.album.return_value = _make_raw_album_meta(genres=None)
+    mock_sc_cls.return_value = mock_client
+
+    song = Song.from_url("https://open.spotify.com/track/abc123")
+
+    assert song.genres == []
+    assert song.name == "Test Song"
+
+
+@patch("spotdl.types.song.SpotifyClient")
+def test_song_from_url_with_genres(mock_sc_cls):
+    """
+    When genres are present, they should still be combined from album + artist.
+    """
+    mock_client = MagicMock()
+    mock_client.track.return_value = _make_raw_track_meta()
+    mock_client.artist.return_value = _make_raw_artist_meta(genres=["pop"])
+    mock_client.album.return_value = _make_raw_album_meta(genres=["rock"])
+    mock_sc_cls.return_value = mock_client
+
+    song = Song.from_url("https://open.spotify.com/track/abc123")
+
+    assert song.genres == ["rock", "pop"]


### PR DESCRIPTION
## Description
Fixes six breaking changes introduced by Spotify's February 2026 API update that prevent spotDL from downloading playlists and individual tracks.

### playlist.py
1. The playlist item response now uses `item` instead of `track` as the key for track metadata. Updated parsing to check for `item` first, falling back to `track` for backward compatibility.

### song.py
2. The `genres` field was removed from album and artist metadata responses. Updated to use `.get()` with empty list fallback instead of direct key access.
3. The label/publisher field was removed from album metadata responses. Updated to use `.get()` instead of direct key access.
4. The `popularity` field was removed from track metadata responses, causing a `KeyError: 'popularity'` on every track. Updated to use `.get("popularity")` instead of direct key access.
5. The `popularity` field used for embedded metadata was still using direct key access, causing a crash when writing track metadata. Updated to use `.get()` for compatibility.

### album.py
6. The label/publisher field was removed from album metadata responses. Updated to use `.get()` instead of direct key access.

## Related Issue
Spotify February 2026 API changelog: https://developer.spotify.com/documentation/web-api/references/changes/february-2026

## Motivation and Context
- Playlist downloads fail silently with "Found 0 songs" because `track.get("track")` now returns `None` for every item
- Individual track downloads crash with `KeyError: 'genres'` since the field no longer exists in album/artist responses
- Embedded metadata writes crash with `KeyError: 'popularity'` when the field is missing from the API response

## How Has This Been Tested?
- Added unit tests mocking both new (`item`) and legacy (`track`) API response formats
- Added unit tests for missing and present `genres` fields
- Verified against Spotify Web API directly using user auth tokens on macOS with spotDL 4.4.3 and Python 3.13

## Screenshots (if appropriate)
N/A

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed