### PR TITLE
fix: pin Docker base image to python:3.13-alpine and skip dev deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.13-alpine
 
 LABEL maintainer="xnetcat (Jakub)"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /app
 COPY . .
 
 # Install spotdl requirements
-RUN uv sync
+RUN uv sync --no-dev
 
 # Create a volume for the output directory
 VOLUME /music


### PR DESCRIPTION
## Description
Two changes to fix the Docker Hub publish workflow:
1. Pin the base image from `python:3-alpine` to `python:3.13-alpine`
2. Add `--no-dev` to `uv sync` to skip dev dependencies in the production image

## Related Issue
https://github.com/spotDL/spotify-downloader/issues/2655
Fixes the nightly Docker Hub publish workflow failure:
https://github.com/spotDL/spotify-downloader/actions/runs/25529616779/job/74932817652

## Motivation and Context
`python:3-alpine` now resolves to Python 3.14. Key native dependencies like `rapidfuzz` don't publish pre-built `musllinux` wheels for cp314 yet. Without a wheel, `uv` falls back to building from the sdist, which fails because `scikit-build-core` rejects `rapidfuzz`'s project metadata.

This was surfaced after commit 7c93c539 widened `requires-python` to `<3.15`, but the actual trigger is Docker Hub updating the `python:3-alpine` floating tag to 3.14. The `requires-python` change is correct for users on glibc systems — only the Docker image needs pinning until upstream deps ship cp314 musl wheels.

The `--no-dev` flag is a separate improvement: dev tools (black, mypy, pylint, pyinstaller) have no place in a runtime container image, and skipping them makes the image smaller and the build faster.

## How Has This Been Tested?
- Built the image locally on an `aarch64` machine with both changes — build succeeds and `spotdl --help` works
- Confirmed `python:3-alpine` currently resolves to Python 3.14.4
- Confirmed `rapidfuzz` 3.12.1 has no cp314 musllinux wheels

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed