### PR TITLE
Retry YouTube Music searches with fresh client

### DIFF
--- a/spotdl/providers/audio/ytmusic.py
+++ b/spotdl/providers/audio/ytmusic.py
@@ -115,7 +115,8 @@ class YouTubeMusic(AudioProvider):
                 return []
 
             logger.debug(
-                "YouTube Music returned no usable results for %s on attempt %s/%s, retrying with a new client",
+                "YouTube Music returned no usable results for %s on attempt %s/%s, "
+                "retrying with a new client",
                 search_term,
                 attempt + 1,
                 self.SEARCH_ATTEMPTS,

--- a/spotdl/providers/audio/ytmusic.py
+++ b/spotdl/providers/audio/ytmusic.py
@@ -2,6 +2,7 @@
 YTMusic module for downloading and searching songs.
 """
 
+import logging
 from typing import Any, Dict, List
 
 from ytmusicapi import YTMusic
@@ -12,6 +13,8 @@ from spotdl.utils.formatter import parse_duration
 
 __all__ = ["YouTubeMusic"]
 
+logger = logging.getLogger(__name__)
+
 
 class YouTubeMusic(AudioProvider):
     """
@@ -19,6 +22,7 @@ class YouTubeMusic(AudioProvider):
     """
 
     SUPPORTS_ISRC = True
+    SEARCH_ATTEMPTS = 3
     GET_RESULTS_OPTS: List[Dict[str, Any]] = [
         {"filter": "songs", "ignore_spelling": True, "limit": 50},
         {"filter": "videos", "ignore_spelling": True, "limit": 50},
@@ -35,7 +39,15 @@ class YouTubeMusic(AudioProvider):
 
         super().__init__(*args, **kwargs)
 
-        self.client = YTMusic(language="de")
+        self.client = self._create_client()
+
+    @staticmethod
+    def _create_client() -> YTMusic:
+        """
+        Create a YTMusic API client.
+        """
+
+        return YTMusic(language="de")
 
     def get_results(self, search_term: str, **kwargs) -> List[Result]:
         """
@@ -54,40 +66,60 @@ class YouTubeMusic(AudioProvider):
         #     print("FORCEFULLY SETTING FILTER TO SONGS")
         #     kwargs["filter"] = "songs"
 
-        search_results = self.client.search(search_term, **kwargs)
+        for attempt in range(self.SEARCH_ATTEMPTS):
+            search_results = self.client.search(search_term, **kwargs)
 
-        # Simplify results
-        results = []
-        for result in search_results:
-            if (
-                result is None
-                or result.get("videoId") is None
-                or result.get("artists") in [[], None]
-            ):
-                continue
+            # Simplify results
+            results = []
+            for result in search_results:
+                if (
+                    result is None
+                    or result.get("videoId") is None
+                    or result.get("artists") in [[], None]
+                ):
+                    continue
 
-            results.append(
-                Result(
-                    source=self.name,
-                    url=(
-                        f'https://{"music" if result["resultType"] == "song" else "www"}'
-                        f".youtube.com/watch?v={result['videoId']}"
-                    ),
-                    verified=result.get("resultType") == "song",
-                    name=result["title"],
-                    result_id=result["videoId"],
-                    author=result["artists"][0]["name"],
-                    artists=tuple(map(lambda a: a["name"], result["artists"])),
-                    duration=parse_duration(result.get("duration")),
-                    isrc_search=is_isrc_result,
-                    search_query=search_term,
-                    explicit=result.get("isExplicit"),
-                    album=(
-                        result.get("album", {}).get("name")
-                        if result.get("album")
-                        else None
-                    ),
+                results.append(
+                    Result(
+                        source=self.name,
+                        url=(
+                            f'https://{"music" if result["resultType"] == "song" else "www"}'
+                            f".youtube.com/watch?v={result['videoId']}"
+                        ),
+                        verified=result.get("resultType") == "song",
+                        name=result["title"],
+                        result_id=result["videoId"],
+                        author=result["artists"][0]["name"],
+                        artists=tuple(map(lambda a: a["name"], result["artists"])),
+                        duration=parse_duration(result.get("duration")),
+                        isrc_search=is_isrc_result,
+                        search_query=search_term,
+                        explicit=result.get("isExplicit"),
+                        album=(
+                            result.get("album", {}).get("name")
+                            if result.get("album")
+                            else None
+                        ),
+                    )
                 )
-            )
 
-        return results
+            if results:
+                return results
+
+            if attempt == self.SEARCH_ATTEMPTS - 1:
+                logger.info(
+                    "YouTube Music returned no usable results for %s after %s attempts",
+                    search_term,
+                    self.SEARCH_ATTEMPTS,
+                )
+                return []
+
+            logger.debug(
+                "YouTube Music returned no usable results for %s on attempt %s/%s, retrying with a new client",
+                search_term,
+                attempt + 1,
+                self.SEARCH_ATTEMPTS,
+            )
+            self.client = self._create_client()
+
+        return []

--- a/tests/providers/audio/test_ytmusic.py
+++ b/tests/providers/audio/test_ytmusic.py
@@ -49,3 +49,31 @@ def test_ytm_get_results():
     results = provider.get_results("Lost Identities Moments")
 
     assert len(results) > 3
+
+
+def test_ytm_get_results_retries_with_new_client(mocker):
+    first_client = mocker.Mock()
+    first_client.search.return_value = []
+    second_client = mocker.Mock()
+    second_client.search.return_value = [
+        {
+            "videoId": "video_0",
+            "resultType": "song",
+            "title": "Test Song",
+            "artists": [{"name": "Test Artist"}],
+            "duration": "1:23",
+        }
+    ]
+    mocker.patch(
+        "spotdl.providers.audio.ytmusic.YTMusic",
+        side_effect=[first_client, second_client],
+    )
+
+    provider = YouTubeMusic()
+    results = provider.get_results("Test Song")
+
+    assert len(results) == 1
+    assert results[0].url == "https://music.youtube.com/watch?v=video_0"
+    assert results[0].name == "Test Song"
+    assert first_client.search.call_count == 1
+    assert second_client.search.call_count == 1


### PR DESCRIPTION
## Summary
- retry YouTube Music searches with a fresh YTMusic client when a client returns no usable results
- log retry attempts at debug level and final failure at info level
- add a regression test for empty first-client results followed by a successful fresh client

## Validation
- .\\.venv\\Scripts\\pytest.exe tests\\providers\\audio\\test_ytmusic.py::test_ytm_get_results_retries_with_new_client
- .\\.venv\\Scripts\\black.exe --check spotdl\\providers\\audio\\ytmusic.py tests\\providers\\audio\\test_ytmusic.py