### PR TITLE
Fix/revert search fallback, recommending Deno instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,11 @@ follow these instructions
 
 ### Installing Deno
 
-Deno is optional, but recommended for most users. Some YouTube videos, including videos marked as
-"made for kids", require Deno when spotDL downloads them through yt-dlp.
+We strongly recommend installing Deno. spotDL uses yt-dlp for YouTube downloads, and some
+videos require Deno to download successfully. Without Deno, spotDL may fail to download some
+songs, including videos marked as "made for kids".
 
-If using Deno only for spotDL, you can install Deno to your spotDL directory:
+If using Deno only for spotDL, install Deno to your spotDL directory:
 `spotdl --download-deno`
 
 If you want to install Deno system-wide instead, follow the

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,10 +58,11 @@ If you require further help, ask in our [Discord Server](https://discord.gg/xCa2
 
 ### Installing Deno
 
-Deno is optional, but recommended for most users. Some YouTube videos, including videos marked as
-"made for kids", require Deno when spotDL downloads them through yt-dlp.
+We strongly recommend installing Deno. spotDL uses yt-dlp for YouTube downloads, and some
+videos require Deno to download successfully. Without Deno, spotDL may fail to download some
+songs, including videos marked as "made for kids".
 
-If using Deno only for spotDL, you can install Deno to your spotDL directory:
+If using Deno only for spotDL, install Deno to your spotDL directory:
 
 ```shell
 spotdl --download-deno

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -53,8 +53,8 @@ As common issues or questions are encountered solutions will be added to this gu
 
 ??? "AudioProviderError: YT-DLP download error"
 
-    This can happen when YouTube videos are tagged as "made for kids". yt-dlp requires Deno for
-    some of these videos.
+    This can happen when Deno is not installed. spotDL uses yt-dlp for YouTube downloads, and some
+    videos require Deno to download successfully, including videos marked as "made for kids".
 
     ### Error Message
 

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -20,7 +20,6 @@ from yt_dlp.postprocessor.sponsorblock import SponsorBlockPP
 from spotdl.download.progress_handler import ProgressHandler
 from spotdl.providers.audio import (
     AudioProvider,
-    AudioProviderError,
     BandCamp,
     Piped,
     SoundCloud,
@@ -40,7 +39,7 @@ from spotdl.utils.config import (
     modernize_settings,
 )
 from spotdl.utils.ffmpeg import FFmpegError, convert, get_ffmpeg_path
-from spotdl.utils.formatter import create_file_name, create_song_title
+from spotdl.utils.formatter import create_file_name
 from spotdl.utils.lrc import generate_lrc
 from spotdl.utils.m3u import gen_m3u_files
 from spotdl.utils.metadata import MetadataError, embed_metadata
@@ -395,40 +394,6 @@ class Downloader:
 
         raise LookupError(f"No results found for song: {song.display_name}")
 
-    def search_all(self, song: Song) -> List[str]:
-        """
-        Search for a song and return all candidate URLs ordered by match score.
-
-        ### Arguments
-        - song: The song to search for.
-
-        ### Returns
-        - list of candidate URLs, best match first.
-        """
-
-        search_query = create_song_title(song.name, song.artists).lower()
-        primaries: List[str] = []
-        secondaries: List[str] = []
-        for audio_provider in self.audio_providers:
-            primary = audio_provider.search(
-                song, self.settings["only_verified_results"]
-            )
-            search_results = audio_provider.get_results(search_query)
-            if self.settings["only_verified_results"]:
-                result_urls = [
-                    result.url for result in search_results if result.verified
-                ]
-            else:
-                result_urls = [result.url for result in search_results]
-
-            if primary in result_urls:
-                result_urls.remove(primary)
-            if primary is not None:
-                primaries.append(primary)
-            secondaries.extend(result_urls)
-        result: List[str] = primaries + secondaries
-        return result
-
     def search_lyrics(self, song: Song) -> Optional[str]:
         """
         Search for lyrics using all available providers.
@@ -709,36 +674,21 @@ class Downloader:
                 display_progress_tracker.yt_dlp_progress_hook
             )
 
-            # Try the best URL first, then fall back to other candidates if yt-dlp fails
-
-            download_info = None
-            candidate_url = None
             if song.download_url is None:
-                candidate_urls = self.search_all(song)
+                download_url = self.search(song)
             else:
-                candidate_urls = [song.download_url]
+                download_url = song.download_url
 
-            for candidate_url in candidate_urls:
-                try:
-                    logger.debug(
-                        "Downloading %s using %s", song.display_name, candidate_url
-                    )
-                    download_info = audio_downloader.get_download_metadata(
-                        candidate_url, download=True
-                    )
-                    break
-                except AudioProviderError as exc:
-                    logger.info(
-                        "yt-dlp failed for %s, trying next URL. Error: %s",
-                        candidate_url,
-                        exc,
-                    )
+            logger.debug("Downloading %s using %s", song.display_name, download_url)
+            download_info = audio_downloader.get_download_metadata(
+                download_url, download=True
+            )
 
             if download_info is None:
                 logger.debug(
                     "No download info found for %s, url: %s",
                     song.display_name,
-                    candidate_url,
+                    download_url,
                 )
 
                 raise DownloaderError(
@@ -840,7 +790,7 @@ class Downloader:
 
             # Set the song's download url
             if song.download_url is None:
-                song.download_url = candidate_url
+                song.download_url = download_url
 
             display_progress_tracker.notify_conversion_complete()
 

--- a/spotdl/providers/audio/base.py
+++ b/spotdl/providers/audio/base.py
@@ -12,7 +12,7 @@ from yt_dlp import YoutubeDL
 from spotdl.types.result import Result
 from spotdl.types.song import Song
 from spotdl.utils.config import get_temp_path
-from spotdl.utils.deno import get_local_deno_yt_dlp_options
+from spotdl.utils.deno import get_local_deno_yt_dlp_options, warn_if_deno_missing
 from spotdl.utils.formatter import (
     args_to_ytdlp_options,
     create_search_query,
@@ -396,6 +396,9 @@ class AudioProvider:
             if data:
                 return data
         except Exception as exception:
+            if download:
+                warn_if_deno_missing()
+
             logger.debug(exception)
             raise AudioProviderError(f"YT-DLP download error - {url}") from exception
 

--- a/spotdl/providers/audio/piped.py
+++ b/spotdl/providers/audio/piped.py
@@ -17,7 +17,7 @@ from spotdl.providers.audio.base import (
 )
 from spotdl.types.result import Result
 from spotdl.utils.config import GlobalConfig, get_temp_path
-from spotdl.utils.deno import get_local_deno_yt_dlp_options
+from spotdl.utils.deno import get_local_deno_yt_dlp_options, warn_if_deno_missing
 from spotdl.utils.formatter import args_to_ytdlp_options
 
 __all__ = ["Piped"]
@@ -196,4 +196,13 @@ class Piped(AudioProvider):
                 }
             )
 
-        return self.audio_handler.process_video_result(yt_dlp_json, download=download)
+        try:
+            return self.audio_handler.process_video_result(
+                yt_dlp_json, download=download
+            )
+        except Exception as exception:
+            if download:
+                warn_if_deno_missing()
+
+            logger.debug(exception)
+            raise AudioProviderError(f"YT-DLP download error - {url}") from exception

--- a/spotdl/utils/deno.py
+++ b/spotdl/utils/deno.py
@@ -55,9 +55,6 @@ DENO_TARGETS: Dict[str, Dict[str, str]] = {
     },
 }
 
-DENO_WARNING_SHOWN = False
-
-
 class DenoError(Exception):
     """
     Base class for all exceptions related to Deno.
@@ -136,18 +133,16 @@ def get_local_deno_yt_dlp_options() -> Dict[str, Dict[str, Dict[str, str]]]:
 
 def warn_if_deno_missing() -> None:
     """
-    Warn once if Deno is unavailable for yt-dlp downloads.
+    Warn if Deno is unavailable for yt-dlp downloads.
     """
 
-    global DENO_WARNING_SHOWN  # pylint: disable=global-statement
-    if DENO_WARNING_SHOWN or is_deno_installed():
+    if is_deno_installed():
         return
 
     logger.warning(
         "Some YouTube downloads require Deno. Run spotdl --download-deno "
         "or install Deno system-wide."
     )
-    DENO_WARNING_SHOWN = True
 
 
 def download_deno() -> Path:

--- a/spotdl/utils/deno.py
+++ b/spotdl/utils/deno.py
@@ -2,6 +2,7 @@
 Module for checking for a Deno binary, finding a local one, and downloading it.
 """
 
+import logging
 import os
 import platform
 import shutil
@@ -15,6 +16,8 @@ import requests
 
 from spotdl.utils.config import get_spotdl_path
 
+logger = logging.getLogger(__name__)
+
 __all__ = [
     "DENO_RELEASE_LATEST_URL",
     "DENO_RELEASE_URL",
@@ -24,6 +27,7 @@ __all__ = [
     "get_deno_path",
     "get_local_deno",
     "get_local_deno_yt_dlp_options",
+    "warn_if_deno_missing",
     "download_deno",
 ]
 
@@ -50,6 +54,8 @@ DENO_TARGETS: Dict[str, Dict[str, str]] = {
         "aarch64": "aarch64-apple-darwin",
     },
 }
+
+DENO_WARNING_SHOWN = False
 
 
 class DenoError(Exception):
@@ -126,6 +132,22 @@ def get_local_deno_yt_dlp_options() -> Dict[str, Dict[str, Dict[str, str]]]:
         return {}
 
     return {"js_runtimes": {"deno": {"path": str(local_deno.absolute())}}}
+
+
+def warn_if_deno_missing() -> None:
+    """
+    Warn once if Deno is unavailable for yt-dlp downloads.
+    """
+
+    global DENO_WARNING_SHOWN  # pylint: disable=global-statement
+    if DENO_WARNING_SHOWN or is_deno_installed():
+        return
+
+    logger.warning(
+        "Some YouTube downloads require Deno. Run spotdl --download-deno "
+        "or install Deno system-wide."
+    )
+    DENO_WARNING_SHOWN = True
 
 
 def download_deno() -> Path:

--- a/spotdl/utils/deno.py
+++ b/spotdl/utils/deno.py
@@ -55,6 +55,7 @@ DENO_TARGETS: Dict[str, Dict[str, str]] = {
     },
 }
 
+
 class DenoError(Exception):
     """
     Base class for all exceptions related to Deno.

--- a/tests/utils/test_search.py
+++ b/tests/utils/test_search.py
@@ -1,7 +1,5 @@
 import pytest
-from unittest.mock import Mock
 
-from spotdl.download.downloader import Downloader
 from spotdl.types.saved import SavedError
 from spotdl.types.song import Song
 from spotdl.utils.search import get_search_results, get_simple_songs, parse_query
@@ -91,52 +89,3 @@ def test_create_empty_song():
 def test_get_simple_songs():
     songs = get_simple_songs(QUERY)
     assert len(songs) > 1
-
-
-def test_search_all_returns_ordered_candidate_urls():
-    downloader = Downloader.__new__(Downloader)
-    downloader.settings = {"only_verified_results": False}
-
-    provider_one = Mock()
-    provider_one.search.return_value = "https://youtube.com/watch?v=primary"
-    provider_one.get_results.return_value = [
-        Mock(url="https://youtube.com/watch?v=primary", verified=True),
-        Mock(url="https://youtube.com/watch?v=secondary1", verified=False),
-    ]
-
-    provider_two = Mock()
-    provider_two.search.return_value = None
-    provider_two.get_results.return_value = [
-        Mock(url="https://youtube.com/watch?v=secondary2", verified=True),
-    ]
-
-    downloader.audio_providers = [provider_one, provider_two]
-
-    song = Song.from_missing_data(name="Test Song", artists=["Artist"])
-    results = downloader.search_all(song)
-
-    assert results == [
-        "https://youtube.com/watch?v=primary",
-        "https://youtube.com/watch?v=secondary1",
-        "https://youtube.com/watch?v=secondary2",
-    ]
-
-
-def test_search_all_respects_verified_only_for_primary_urls():
-    downloader = Downloader.__new__(Downloader)
-    downloader.settings = {"only_verified_results": True}
-
-    provider = Mock()
-    provider.search.return_value = None
-    provider.get_results.return_value = [
-        Mock(url="https://youtube.com/watch?v=verified", verified=True),
-        Mock(url="https://youtube.com/watch?v=unverified", verified=False),
-    ]
-
-    downloader.audio_providers = [provider]
-
-    song = Song.from_missing_data(name="Test Song", artists=["Artist"])
-    results = downloader.search_all(song)
-
-    provider.search.assert_called_once_with(song, True)
-    assert results == ["https://youtube.com/watch?v=verified"]


### PR DESCRIPTION
See dev channels
https://discord.com/channels/771628785447337985/804926132632682496/1504625425585012746

PR #2672 removes the `search_all()` fallback path because it introduced a risky behavior change: only the primary URL was selected through spotDL’s normal matching/scoring logic, while secondary URLs were raw provider search results. If yt-dlp failed on the primary URL, spotDL could attempt to download an unrelated raw search result instead of failing cleanly. Since needing a secondary match is rare, reverting to a single vetted URL is the safer release behavior.

The PR also addresses the likely reason this fallback was useful in practice: yt-dlp can fail for some YouTube downloads when Deno is not installed. Instead of trying less-trusted fallback URLs, spotDL now warns users when yt-dlp fails and Deno is missing, and the docs more strongly recommend installing Deno because spotDL may fail to download some songs without it.