### PR TITLE
fix: use absolute path for web UI templates directory

### DIFF
--- a/spotdl/web/routes.py
+++ b/spotdl/web/routes.py
@@ -4,6 +4,7 @@ Module which contains the web client routes and functions.
 
 import asyncio
 import uuid
+from pathlib import Path
 from typing import Any, Optional, cast
 
 # from datastar_py.sse import DatastarEvent
@@ -28,7 +29,7 @@ __all__ = ["router"]
 
 router = APIRouter()
 
-templates = Jinja2Templates(directory="spotdl/web/components")
+templates = Jinja2Templates(directory=str(Path(__file__).parent / "components"))
 
 
 # PATHS


### PR DESCRIPTION
## Description
Changed `Jinja2Templates` initialization in `spotdl/web/routes.py` from a relative path to an absolute path using `Path(__file__).parent /
"components"`.

## Related Issue
N/A

## Motivation and Context
Running `spotdl web` and visiting `http://localhost:8800/` returns a 500 Internal Server Error with `jinja2.exceptions.TemplateNotFound:
'home.html.j2' not found in search path: 'spotdl/web/components'`. This is because the template directory is set to a relative path, which
only resolves if the user's working directory happens to be the `site-packages` folder. Using an absolute path derived from `__file__`
ensures templates are always found regardless of where `spotdl` is invoked from.

## How Has This Been Tested?
- Ran `spotdl web` from a home directory (not site-packages)
- Confirmed `GET /` returned 500 before the fix
- Confirmed `GET /` returned 200 after the fix
- Verified the web UI loads correctly in the browser

## Screenshots (if appropriate)
<img width="1348" height="1434" alt="WindowsTerminal_wQXD75xxz6" src="https://github.com/user-attachments/assets/32a868ea-e8ee-4280-aecd-ad757f7dbc4b" />

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed