### PR TITLE
Fix AZLyrics redirect-loop block and surface lyrics provider errors in debug logs

### DIFF
--- a/spotdl/providers/lyrics/azlyrics.py
+++ b/spotdl/providers/lyrics/azlyrics.py
@@ -41,7 +41,7 @@ class AzLyrics(LyricsProvider):
             }
         )
 
-        self.x_code = self._get_x_code()
+        self.x_code = None
 
     def get_results(self, name: str, artists: List[str], **_) -> Dict[str, str]:
         """

--- a/spotdl/providers/lyrics/azlyrics.py
+++ b/spotdl/providers/lyrics/azlyrics.py
@@ -27,10 +27,6 @@ class AzLyrics(LyricsProvider):
         self.session.headers.update(
             {
                 "Host": "www.azlyrics.com",
-                "User-Agent": (
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-                    "(KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36"
-                ),
                 "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
                 "Accept-Language": "en-US,en;q=0.5",
                 "Accept-Encoding": "gzip, deflate, br, zstd",

--- a/spotdl/providers/lyrics/azlyrics.py
+++ b/spotdl/providers/lyrics/azlyrics.py
@@ -24,6 +24,9 @@ class AzLyrics(LyricsProvider):
         super().__init__()
 
         self.session = requests.Session()
+        # No User-Agent override: AZLyrics traps requests claiming to be a
+        # browser in a redirect loop, while requests' default UA is served
+        # normally (see #2682).
         self.session.headers.update(
             {
                 "Host": "www.azlyrics.com",

--- a/spotdl/providers/lyrics/genius.py
+++ b/spotdl/providers/lyrics/genius.py
@@ -58,10 +58,13 @@ class Genius(LyricsProvider):
             headers=self.headers,
             timeout=10,
             proxies=GlobalConfig.get_parameter("proxies"),
-        )
+        ).json()
+
+        if "response" not in search_response:
+            raise Exception(search_response["meta"]["message"])
 
         results: Dict[str, str] = {}
-        for hit in search_response.json()["response"]["hits"]:
+        for hit in search_response["response"]["hits"]:
             results[hit["result"]["full_title"]] = hit["result"]["id"]
 
         return results

--- a/spotdl/providers/lyrics/genius.py
+++ b/spotdl/providers/lyrics/genius.py
@@ -61,7 +61,9 @@ class Genius(LyricsProvider):
         ).json()
 
         if "response" not in search_response:
-            raise Exception(search_response["meta"]["message"])
+            raise RuntimeError(
+                search_response.get("meta", {}).get("message", "Unknown API error")
+            )
 
         results: Dict[str, str] = {}
         for hit in search_response["response"]["hits"]:

--- a/spotdl/providers/lyrics/musixmatch.py
+++ b/spotdl/providers/lyrics/musixmatch.py
@@ -78,7 +78,7 @@ class MusixMatch(LyricsProvider):
             proxies=GlobalConfig.get_parameter("proxies"),
         )
 
-       if not search_resp.ok:
+        if not search_resp.ok:
             raise RuntimeError(
                 f"Received HTTP {search_resp.status_code} from {search_url}"
             )

--- a/spotdl/providers/lyrics/musixmatch.py
+++ b/spotdl/providers/lyrics/musixmatch.py
@@ -78,8 +78,10 @@ class MusixMatch(LyricsProvider):
             proxies=GlobalConfig.get_parameter("proxies"),
         )
 
-        if search_resp.status_code:
-            raise Exception("Recieved 403 unauthorized")
+       if not search_resp.ok:
+            raise RuntimeError(
+                f"Received HTTP {search_resp.status_code} from {search_url}"
+            )
 
         search_soup = BeautifulSoup(search_resp.text, "html.parser")
         song_url_tag = search_soup.select("a[href^='/lyrics/']")

--- a/spotdl/providers/lyrics/musixmatch.py
+++ b/spotdl/providers/lyrics/musixmatch.py
@@ -77,6 +77,10 @@ class MusixMatch(LyricsProvider):
             timeout=10,
             proxies=GlobalConfig.get_parameter("proxies"),
         )
+
+        if search_resp.status_code:
+            raise Exception("Recieved 403 unauthorized")
+
         search_soup = BeautifulSoup(search_resp.text, "html.parser")
         song_url_tag = search_soup.select("a[href^='/lyrics/']")
 


### PR DESCRIPTION
### EDITED BY @Silverarmor 
## Description
Three related fixes to the lyrics providers:

**AZLyrics** : AZLyrics blocks requests that claim to be Chrome by continuously
redirecting them (~30 HTTP requests before timing out). Removed the User-Agent
override so requests' default UA is used, which AZLyrics serves normally. Also
made `x_code` initialization lazy, so the (previously slow) AZLyrics setup no
longer delays spotdl startup.

**MusixMatch** - search requests now raise on non-OK responses, so failures are
visible in debug logs instead of silently returning no lyrics. MusixMatch
currently blocks all non-browser clients with HTTP 403 (see #2741), which this
makes diagnosable.

**Genius** : search response errors (e.g. the 429 docs-API rate limit) are now
surfaced in debug logs with the API's own error message, instead of failing
with an unrelated `KeyError`.

## Related Issue
#2682 (AZLyrics discussion), #2741 (MusixMatch 403)

## Motivation and Context
Fixes AZLyrics lyrics fetching, speeds up spotdl startup, and makes lyrics
provider failures debuggable via `--log-level DEBUG` instead of silent.

## How Has This Been Tested?
Downloaded a song and verified lyrics were fetched via AZLyrics. Verified the
MusixMatch and Genius error paths surface their errors in debug logs, and that
successful responses still parse correctly. Lint suite (pylint, mypy, black,
isort) passes.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

<details>
  <summary>ORIGINAL</summary>



## Description
AZLyrics blocks* us with the user agent we're currently using, so I've switched to the default one for `LyricsProvider`s.

\*'blocks' us by continuously redirecting us, causing 30 HTTP requests before it times out (this is why initializing AZLyrics took so long).


## Related Issue
#2682 (I know it's not an issue, but there was some discussion nontheless).

## Motivation and Context
This fixes AZLyrics and speeds up spotdl's startup.

## How Has This Been Tested?
I've downloaded a song and checked that it was able to fetch the lyrics.

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

</details> 