### PR TITLE
Populate artists in SoundCloud from author, fall back to author in artist match if no artists

### DIFF
--- a/spotdl/providers/audio/bandcamp.py
+++ b/spotdl/providers/audio/bandcamp.py
@@ -170,7 +170,7 @@ class BandCamp(AudioProvider):
 
     def get_results(self, search_term: str, *_args, **_kwargs) -> List[Result]:
         """
-        Get results from slider.kz
+        Get results from BandCamp
 
         ### Arguments
         - search_term: The search term to search for.
@@ -178,7 +178,7 @@ class BandCamp(AudioProvider):
         - kwargs: Unused.
 
         ### Returns
-        - A list of slider.kz results if found, None otherwise.
+        - A list of BandCamp results if found, None otherwise.
         """
 
         try:

--- a/spotdl/providers/audio/soundcloud.py
+++ b/spotdl/providers/audio/soundcloud.py
@@ -83,6 +83,7 @@ class SoundCloud(AudioProvider):
                     verified=result.user.verified,
                     duration=result.full_duration,
                     author=result.user.username,
+                    artists=(result.user.username,),
                     result_id=str(result.id),
                     isrc_search=False,
                     search_query=search_term,

--- a/spotdl/providers/audio/soundcloud.py
+++ b/spotdl/providers/audio/soundcloud.py
@@ -40,7 +40,7 @@ class SoundCloud(AudioProvider):
 
     def get_results(self, search_term: str, *_args, **_kwargs) -> List[Result]:
         """
-        Get results from slider.kz
+        Get results from SoundCloud
 
         ### Arguments
         - search_term: The search term to search for.
@@ -48,7 +48,7 @@ class SoundCloud(AudioProvider):
         - kwargs: Unused.
 
         ### Returns
-        - A list of slider.kz results if found, None otherwise.
+        - A list of SoundCloud results if found, None otherwise.
         """
 
         results = list(islice(self.client.search(search_term), 20))

--- a/spotdl/utils/matching.py
+++ b/spotdl/utils/matching.py
@@ -287,8 +287,7 @@ def get_best_matches(
 
 def calc_main_artist_match(song: Song, result: Result) -> float:
     """
-    Calculate how well the main artist of the song matches the result.
-    Falls back to result.author if result.artists is not populated.
+    Calculate how well the song's main artist matches the result artists.
 
     ### Arguments
     - song: song to match
@@ -300,13 +299,9 @@ def calc_main_artist_match(song: Song, result: Result) -> float:
 
     main_artist_match = 0.0
 
-    # Result has no artists, fall back to author
-    # If no author either, return 0.0
+    # Result has no artists, return 0.0
     if not result.artists:
-        if not result.author:
-            return main_artist_match
-
-        return ratio(slugify(song.artists[0]), slugify(result.author))
+        return main_artist_match
 
     song_artists, result_artists = list(map(slugify, song.artists)), list(
         map(slugify, result.artists)

--- a/spotdl/utils/matching.py
+++ b/spotdl/utils/matching.py
@@ -287,14 +287,15 @@ def get_best_matches(
 
 def calc_main_artist_match(song: Song, result: Result) -> float:
     """
-    Check if main artist is present in list of artists
+    Calculate how well the main artist of the song matches the result.
+    Falls back to result.author if result.artists is not populated.
 
     ### Arguments
-    - main_artist: main artist to check
-    - artists: list of artists to check
+    - song: song to match
+    - result: result to match
 
     ### Returns
-    - True if main artist is present in list of artists, False otherwise
+    - artist match percentage (0.0 to 100.0)
     """
 
     main_artist_match = 0.0

--- a/spotdl/utils/matching.py
+++ b/spotdl/utils/matching.py
@@ -299,9 +299,13 @@ def calc_main_artist_match(song: Song, result: Result) -> float:
 
     main_artist_match = 0.0
 
-    # Result has no artists, return 0.0
+    # Result has no artists, fall back to author
+    # If no author either, return 0.0
     if not result.artists:
-        return main_artist_match
+        if not result.author:
+            return main_artist_match
+
+        return ratio(slugify(song.artists[0]), slugify(result.author))
 
     song_artists, result_artists = list(map(slugify, song.artists)), list(
         map(slugify, result.artists)

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -2,9 +2,7 @@ import pytest
 
 from spotdl.providers.audio.base import AudioProviderError
 from spotdl.providers.audio.ytmusic import YouTubeMusic
-from spotdl.types.result import Result
 from spotdl.types.song import Song
-from spotdl.utils.matching import calc_main_artist_match
 from spotdl.utils.spotify import SpotifyClient
 from tests.conftest import new_initialize
 
@@ -431,93 +429,3 @@ def test_ytmusic_matching(monkeypatch, query, expected, capsys):
 
     except AudioProviderError:
         pytest.skip("YouTube Music search failed")
-
-
-SONG_DICT = {
-    "name": "流転の果て",
-    "artists": ["tokiwa"],
-    "artist": "tokiwa",
-    "album_id": "test",
-    "album_name": "勿忘",
-    "album_artist": "tokiwa",
-    "album_type": "album",
-    "genres": [],
-    "disc_number": 1,
-    "disc_count": 1,
-    "duration": 222,
-    "year": 2023,
-    "date": "2023-01-01",
-    "track_number": 1,
-    "tracks_count": 1,
-    "isrc": "",
-    "song_id": "7yfMsNxODzSIysdZ47JrlG",
-    "cover_url": "https://example.com/cover.jpg",
-    "explicit": False,
-    "publisher": "test",
-    "url": "https://open.spotify.com/track/7yfMsNxODzSIysdZ47JrlG",
-    "copyright_text": "",
-}
-
-
-def test_calc_main_artist_match_with_artists():
-    song = Song.from_dict(SONG_DICT)
-    result = Result(
-        source="soundcloud",
-        url="https://soundcloud.com/tokiwa_anka/pnog8medav1f",
-        verified=False,
-        name="流転の果て",
-        duration=222041,
-        author="tokiwa",
-        artists=("tokiwa",),
-        result_id="941283319",
-    )
-
-    assert calc_main_artist_match(song, result) == 100.0
-
-
-def test_calc_main_artist_match_falls_back_to_author():
-    song = Song.from_dict(SONG_DICT)
-    result = Result(
-        source="soundcloud",
-        url="https://soundcloud.com/tokiwa_anka/pnog8medav1f",
-        verified=False,
-        name="流転の果て",
-        duration=222041,
-        author="tokiwa",
-        result_id="941283319",
-    )
-
-    assert result.artists is None
-    assert calc_main_artist_match(song, result) == 100.0
-
-
-def test_calc_main_artist_match_no_artists_no_author():
-    song = Song.from_dict(SONG_DICT)
-    result = Result(
-        source="soundcloud",
-        url="https://soundcloud.com/unknown/test",
-        verified=False,
-        name="流転の果て",
-        duration=222041,
-        author="",
-        result_id="000",
-    )
-
-    assert result.artists is None
-    assert calc_main_artist_match(song, result) == 0.0
-
-
-def test_calc_main_artist_match_author_fuzzy():
-    song = Song.from_dict({**SONG_DICT, "artists": ["Carly Rae Jepsen"], "artist": "Carly Rae Jepsen"})
-    result = Result(
-        source="youtube",
-        url="https://www.youtube.com/watch?v=abc",
-        verified=False,
-        name="I Really Like You",
-        duration=200,
-        author="Carly Rae Jepsen - Topic",
-        result_id="abc",
-    )
-
-    assert result.artists is None
-    assert calc_main_artist_match(song, result) > 70.0

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -2,7 +2,9 @@ import pytest
 
 from spotdl.providers.audio.base import AudioProviderError
 from spotdl.providers.audio.ytmusic import YouTubeMusic
+from spotdl.types.result import Result
 from spotdl.types.song import Song
+from spotdl.utils.matching import calc_main_artist_match
 from spotdl.utils.spotify import SpotifyClient
 from tests.conftest import new_initialize
 
@@ -429,3 +431,93 @@ def test_ytmusic_matching(monkeypatch, query, expected, capsys):
 
     except AudioProviderError:
         pytest.skip("YouTube Music search failed")
+
+
+SONG_DICT = {
+    "name": "流転の果て",
+    "artists": ["tokiwa"],
+    "artist": "tokiwa",
+    "album_id": "test",
+    "album_name": "勿忘",
+    "album_artist": "tokiwa",
+    "album_type": "album",
+    "genres": [],
+    "disc_number": 1,
+    "disc_count": 1,
+    "duration": 222,
+    "year": 2023,
+    "date": "2023-01-01",
+    "track_number": 1,
+    "tracks_count": 1,
+    "isrc": "",
+    "song_id": "7yfMsNxODzSIysdZ47JrlG",
+    "cover_url": "https://example.com/cover.jpg",
+    "explicit": False,
+    "publisher": "test",
+    "url": "https://open.spotify.com/track/7yfMsNxODzSIysdZ47JrlG",
+    "copyright_text": "",
+}
+
+
+def test_calc_main_artist_match_with_artists():
+    song = Song.from_dict(SONG_DICT)
+    result = Result(
+        source="soundcloud",
+        url="https://soundcloud.com/tokiwa_anka/pnog8medav1f",
+        verified=False,
+        name="流転の果て",
+        duration=222041,
+        author="tokiwa",
+        artists=("tokiwa",),
+        result_id="941283319",
+    )
+
+    assert calc_main_artist_match(song, result) == 100.0
+
+
+def test_calc_main_artist_match_falls_back_to_author():
+    song = Song.from_dict(SONG_DICT)
+    result = Result(
+        source="soundcloud",
+        url="https://soundcloud.com/tokiwa_anka/pnog8medav1f",
+        verified=False,
+        name="流転の果て",
+        duration=222041,
+        author="tokiwa",
+        result_id="941283319",
+    )
+
+    assert result.artists is None
+    assert calc_main_artist_match(song, result) == 100.0
+
+
+def test_calc_main_artist_match_no_artists_no_author():
+    song = Song.from_dict(SONG_DICT)
+    result = Result(
+        source="soundcloud",
+        url="https://soundcloud.com/unknown/test",
+        verified=False,
+        name="流転の果て",
+        duration=222041,
+        author="",
+        result_id="000",
+    )
+
+    assert result.artists is None
+    assert calc_main_artist_match(song, result) == 0.0
+
+
+def test_calc_main_artist_match_author_fuzzy():
+    song = Song.from_dict({**SONG_DICT, "artists": ["Carly Rae Jepsen"], "artist": "Carly Rae Jepsen"})
+    result = Result(
+        source="youtube",
+        url="https://www.youtube.com/watch?v=abc",
+        verified=False,
+        name="I Really Like You",
+        duration=200,
+        author="Carly Rae Jepsen - Topic",
+        result_id="abc",
+    )
+
+    assert result.artists is None
+    assert calc_main_artist_match(song, result) > 70.0


### PR DESCRIPTION
# Title
<!--- Provide a general summary of your changes in the Title above -->
Populate the artists field in the SoundCloud audio provider results (the uploader is very commonly the artist on SoundCloud)

## Description
- Populates artists in SoundCloud from author (uploader). The author and the artist are often the same on SoundCloud.
- Fall back to the author in artist matching in general in matching.py if the artists field is not populated.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/spotDL/spotify-downloader/issues/2704

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes cases similar to what is mentioned in the linked incident in which tracks are not matched that were uploaded by the artist in question.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Validated locally by running code for the case mentioned in the linked issue and added unit tests to test_matching.py.

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed (Note: Any failing tests here were failing before my changes)