### PR TITLE
docs: add installation instructions for uv tool in documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -85,7 +85,7 @@ Refer to our [Installation Guide](installation.md) for more details.
     pip install uv
     uv sync
     uv run scripts/build.py
-    `
+    ```
 
     An executable is created in `spotify-downloader/dist/`.
 
@@ -94,7 +94,7 @@ Refer to our [Installation Guide](installation.md) for more details.
   ```bash
   uv tool install spotdl
   ```
-  
+
 ### Installing FFmpeg
 
 FFmpeg is required for spotDL. If using FFmpeg only for spotDL, you can simply install FFmpeg to your spotDL installation directory:

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,10 +85,16 @@ Refer to our [Installation Guide](installation.md) for more details.
     pip install uv
     uv sync
     uv run scripts/build.py
-    ```
+    `
 
     An executable is created in `spotify-downloader/dist/`.
 
+- uv tool
+
+  ```bash
+  uv tool install spotdl
+  ```
+  
 ### Installing FFmpeg
 
 FFmpeg is required for spotDL. If using FFmpeg only for spotDL, you can simply install FFmpeg to your spotDL installation directory:


### PR DESCRIPTION
# Title
Add installation instructions for uv tool in documentation

## Description
add `uv tool install spotdl` to `index.md`

## Motivation and Context
Some people like me find this more convenient

## How Has This Been Tested?
Installed it myself


## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
