### PR TITLE
feat: Add Exportify auth fallback and CSV import workaround for saved/liked tracks

### DIFF
--- a/spotdl/console/entry_point.py
+++ b/spotdl/console/entry_point.py
@@ -164,17 +164,6 @@ def entry_point():
     ):
         raise DownloaderError("Save file has to end with .spotdl")
 
-    # Check if the user is logged in (skip this check for CSV imports)
-    if (
-        arguments.query
-        and "saved" in arguments.query
-        and not spotify_settings["user_auth"]
-        and not from_csv
-    ):
-        raise SpotifyError(
-            "You must be logged in to use the saved query. "
-            "Log in by adding the --user-auth flag"
-        )
 
     # Initialize the downloader
     # for download, load and preload operations

--- a/spotdl/console/entry_point.py
+++ b/spotdl/console/entry_point.py
@@ -77,6 +77,43 @@ def entry_point():
     # Parse the arguments
     arguments = parse_arguments()
 
+    # Handle --from-csv: inject CSV path into query
+    from_csv = getattr(arguments, "from_csv", None)
+    if from_csv:
+        import os
+
+        if not os.path.isfile(from_csv):
+            raise FileNotFoundError(
+                f"CSV file not found: {from_csv}\n"
+                "Make sure the path to your Exportify CSV file is correct."
+            )
+
+        if not from_csv.lower().endswith(".csv"):
+            raise ValueError(
+                f"File does not have .csv extension: {from_csv}\n"
+                "Please provide a valid CSV file exported from Exportify."
+            )
+
+        # If no query provided, create one with just the CSV path
+        if not hasattr(arguments, "query") or arguments.query is None:
+            arguments.query = [from_csv]
+        else:
+            # Prepend CSV to existing query
+            arguments.query = [from_csv] + arguments.query
+
+        # Default to download operation if not specified
+        if (
+            not hasattr(arguments, "operation")
+            or arguments.operation is None
+        ):
+            arguments.operation = "download"
+
+        logger.info(
+            "Using Exportify CSV: %s (operation: %s)",
+            from_csv,
+            arguments.operation,
+        )
+
     # Create settings dicts
     spotify_settings, downloader_settings, web_settings = create_settings(arguments)
 
@@ -127,11 +164,12 @@ def entry_point():
     ):
         raise DownloaderError("Save file has to end with .spotdl")
 
-    # Check if the user is logged in
+    # Check if the user is logged in (skip this check for CSV imports)
     if (
         arguments.query
         and "saved" in arguments.query
         and not spotify_settings["user_auth"]
+        and not from_csv
     ):
         raise SpotifyError(
             "You must be logged in to use the saved query. "

--- a/spotdl/types/csv_import.py
+++ b/spotdl/types/csv_import.py
@@ -1,0 +1,488 @@
+"""
+CSV Import module for loading songs from Exportify CSV exports.
+
+Exportify (https://exportify.net) exports Spotify playlists and liked songs
+as CSV files. This module parses those CSVs and creates Song objects that
+spotDL can download, bypassing the Spotify Web API's /me/tracks endpoint
+which requires Premium on the app owner's account.
+
+Exportify CSV columns (in order):
+    Spotify ID, Artist IDs, Track Name, Album Name, Artist Name(s),
+    Release Date, Duration (ms), Popularity, Added By, Added At,
+    Genres, Record Label, Danceability, Energy, Key, Loudness, Mode,
+    Speechiness, Acousticness, Instrumentalness, Liveness, Valence,
+    Tempo, Time Signature, Spotify URL
+"""
+
+import csv
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from spotdl.types.song import Song, SongList
+
+__all__ = ["CSVImport", "CSVImportError"]
+
+logger = logging.getLogger(__name__)
+
+# Expected Exportify column headers (case-insensitive matching)
+EXPORTIFY_COLUMNS = [
+    "spotify id",
+    "artist ids",
+    "track name",
+    "album name",
+    "artist name(s)",
+    "release date",
+    "duration (ms)",
+    "popularity",
+    "added by",
+    "added at",
+    "genres",
+    "record label",
+    "danceability",
+    "energy",
+    "key",
+    "loudness",
+    "mode",
+    "speechiness",
+    "acousticness",
+    "instrumentalness",
+    "liveness",
+    "valence",
+    "tempo",
+    "time signature",
+    "spotify url",  # Not always present in older exports
+]
+
+# Minimum required columns for a valid import
+REQUIRED_COLUMNS = {"track name", "artist name(s)"}
+
+
+class CSVImportError(Exception):
+    """
+    Base class for all exceptions related to CSV import.
+    """
+
+
+def _detect_encoding(file_path: Path) -> str:
+    """
+    Detect file encoding by checking for BOM markers.
+    Falls back to utf-8.
+
+    ### Arguments
+    - file_path: Path to the CSV file.
+
+    ### Returns
+    - The detected encoding string.
+    """
+    with open(file_path, "rb") as f:
+        raw = f.read(4)
+
+    if raw.startswith(b"\xef\xbb\xbf"):
+        return "utf-8-sig"
+    if raw.startswith(b"\xff\xfe"):
+        return "utf-16-le"
+    if raw.startswith(b"\xfe\xff"):
+        return "utf-16-be"
+    return "utf-8"
+
+
+def _normalize_header(header: str) -> str:
+    """
+    Normalize a CSV header for matching: lowercase, strip whitespace.
+    """
+    return header.strip().lower()
+
+
+def _parse_artists(artist_string: str) -> List[str]:
+    """
+    Parse the 'Artist Name(s)' field from Exportify.
+    Artists are comma-separated in the CSV.
+
+    ### Arguments
+    - artist_string: The raw artist names string.
+
+    ### Returns
+    - List of individual artist names.
+    """
+    if not artist_string or not artist_string.strip():
+        return []
+
+    # Exportify separates multiple artists with ", "
+    artists = [a.strip() for a in artist_string.split(",")]
+    return [a for a in artists if a]
+
+
+def _parse_genres(genre_string: str) -> List[str]:
+    """
+    Parse the 'Genres' field from Exportify.
+
+    ### Arguments
+    - genre_string: The raw genres string.
+
+    ### Returns
+    - List of genre strings.
+    """
+    if not genre_string or not genre_string.strip():
+        return []
+
+    # Genres may be comma-separated or semicolon-separated
+    for sep in [",", ";"]:
+        if sep in genre_string:
+            return [g.strip() for g in genre_string.split(sep) if g.strip()]
+
+    return [genre_string.strip()] if genre_string.strip() else []
+
+
+def _safe_int(value: str, default: Optional[int] = None) -> Optional[int]:
+    """Safely convert a string to int, returning default on failure."""
+    if not value or not value.strip():
+        return default
+    try:
+        return int(float(value.strip()))
+    except (ValueError, TypeError):
+        return default
+
+
+def _build_spotify_url(song_id: str) -> str:
+    """Build a Spotify track URL from a track ID."""
+    if song_id.startswith("http"):
+        return song_id
+    return f"https://open.spotify.com/track/{song_id}"
+
+
+def parse_csv_file(file_path: Path) -> Tuple[Dict[str, Any], List[Song]]:
+    """
+    Parse an Exportify CSV file and return metadata + Song objects.
+
+    ### Arguments
+    - file_path: Path to the CSV file.
+
+    ### Returns
+    - Tuple of (metadata dict, list of Song objects).
+
+    ### Raises
+    - CSVImportError: If the file cannot be parsed or is invalid.
+    """
+    if not file_path.exists():
+        raise CSVImportError(f"CSV file not found: {file_path}")
+
+    if not file_path.is_file():
+        raise CSVImportError(f"Path is not a file: {file_path}")
+
+    encoding = _detect_encoding(file_path)
+    logger.info("Reading CSV file: %s (encoding: %s)", file_path, encoding)
+
+    try:
+        with open(file_path, "r", encoding=encoding, newline="") as f:
+            # Sniff delimiter (Exportify uses comma, but be flexible)
+            sample = f.read(4096)
+            f.seek(0)
+
+            try:
+                dialect = csv.Sniffer().sniff(sample, delimiters=",;\t")
+            except csv.Error:
+                dialect = csv.excel  # Default to standard CSV
+
+            reader = csv.reader(f, dialect)
+
+            # Read and validate header
+            try:
+                raw_headers = next(reader)
+            except StopIteration:
+                raise CSVImportError("CSV file is empty")
+
+            headers = [_normalize_header(h) for h in raw_headers]
+
+            # Build column index map
+            col_map = {}
+            for i, header in enumerate(headers):
+                col_map[header] = i
+
+            # Check for required columns
+            missing = REQUIRED_COLUMNS - set(col_map.keys())
+            if missing:
+                # Try fuzzy matching for common variations
+                header_aliases = {
+                    "track name": ["name", "title", "song name", "song title", "track"],
+                    "artist name(s)": [
+                        "artist",
+                        "artists",
+                        "artist names",
+                        "artist name",
+                    ],
+                }
+                for req_col in list(missing):
+                    for alias in header_aliases.get(req_col, []):
+                        if alias in col_map:
+                            col_map[req_col] = col_map[alias]
+                            missing.discard(req_col)
+                            break
+
+            if missing:
+                raise CSVImportError(
+                    f"CSV is missing required columns: {', '.join(missing)}. "
+                    f"Found columns: {', '.join(headers)}. "
+                    f"Make sure you're using an Exportify CSV export."
+                )
+
+            # Parse rows into Song objects
+            songs: List[Song] = []
+            skipped = 0
+            errors_list: List[str] = []
+
+            for row_num, row in enumerate(reader, start=2):
+                try:
+                    song = _row_to_song(row, col_map, row_num)
+                    if song is not None:
+                        songs.append(song)
+                    else:
+                        skipped += 1
+                except Exception as exc:
+                    skipped += 1
+                    error_msg = f"Row {row_num}: {exc}"
+                    errors_list.append(error_msg)
+                    logger.debug("Skipping row %d: %s", row_num, exc)
+
+            if errors_list:
+                logger.warning(
+                    "Encountered %d errors while parsing CSV. "
+                    "First error: %s",
+                    len(errors_list),
+                    errors_list[0],
+                )
+
+            logger.info(
+                "Parsed %d songs from CSV (%d skipped)",
+                len(songs),
+                skipped,
+            )
+
+            if len(songs) == 0:
+                raise CSVImportError(
+                    "No valid songs found in CSV file. "
+                    "Make sure the file is a valid Exportify export."
+                )
+
+            metadata = {
+                "name": file_path.stem,
+                "url": f"csv:{file_path.name}",
+            }
+
+            return metadata, songs
+
+    except UnicodeDecodeError:
+        # Retry with latin-1 as a fallback
+        logger.warning("UTF-8 decode failed, retrying with latin-1 encoding")
+        try:
+            return _parse_with_encoding(file_path, "latin-1")
+        except Exception as exc:
+            raise CSVImportError(
+                f"Could not decode CSV file with any supported encoding: {exc}"
+            ) from exc
+    except CSVImportError:
+        raise
+    except Exception as exc:
+        raise CSVImportError(f"Failed to parse CSV file: {exc}") from exc
+
+
+def _parse_with_encoding(
+    file_path: Path, encoding: str
+) -> Tuple[Dict[str, Any], List[Song]]:
+    """
+    Parse CSV with a specific encoding (fallback path).
+    """
+    with open(file_path, "r", encoding=encoding, newline="") as f:
+        reader = csv.reader(f)
+
+        raw_headers = next(reader)
+        headers = [_normalize_header(h) for h in raw_headers]
+        col_map = {header: i for i, header in enumerate(headers)}
+
+        missing = REQUIRED_COLUMNS - set(col_map.keys())
+        if missing:
+            raise CSVImportError(
+                f"CSV is missing required columns: {', '.join(missing)}"
+            )
+
+        songs = []
+        for row_num, row in enumerate(reader, start=2):
+            try:
+                song = _row_to_song(row, col_map, row_num)
+                if song is not None:
+                    songs.append(song)
+            except Exception as exc:
+                logger.debug("Skipping row %d: %s", row_num, exc)
+
+        metadata = {
+            "name": file_path.stem,
+            "url": f"csv:{file_path.name}",
+        }
+
+        return metadata, songs
+
+
+def _get_col(row: list, col_map: dict, col_name: str, default: str = "") -> str:
+    """
+    Safely get a column value from a row.
+    """
+    idx = col_map.get(col_name)
+    if idx is None or idx >= len(row):
+        return default
+    return row[idx].strip() if row[idx] else default
+
+
+def _row_to_song(
+    row: list, col_map: dict, row_num: int
+) -> Optional[Song]:
+    """
+    Convert a single CSV row to a Song object.
+
+    ### Arguments
+    - row: The CSV row as a list of strings.
+    - col_map: Mapping of column names to indices.
+    - row_num: The row number (for error reporting).
+
+    ### Returns
+    - Song object, or None if the row should be skipped.
+    """
+    track_name = _get_col(row, col_map, "track name")
+    artist_names_raw = _get_col(row, col_map, "artist name(s)")
+
+    # Skip empty rows
+    if not track_name:
+        return None
+
+    artists = _parse_artists(artist_names_raw)
+    if not artists:
+        logger.debug("Row %d: No artist found for '%s', skipping", row_num, track_name)
+        return None
+
+    # Extract all available fields
+    song_id = _get_col(row, col_map, "spotify id")
+    album_name = _get_col(row, col_map, "album name")
+    release_date = _get_col(row, col_map, "release date")
+    duration_ms_str = _get_col(row, col_map, "duration (ms)")
+    popularity_str = _get_col(row, col_map, "popularity")
+    genres_raw = _get_col(row, col_map, "genres")
+    record_label = _get_col(row, col_map, "record label")
+    spotify_url = _get_col(row, col_map, "spotify url")
+
+    # Compute derived values
+    duration_ms = _safe_int(duration_ms_str)
+    duration_sec = int(duration_ms / 1000) if duration_ms else None
+    popularity = _safe_int(popularity_str)
+    genres = _parse_genres(genres_raw)
+    year = None
+    if release_date:
+        try:
+            year = int(release_date[:4])
+        except (ValueError, IndexError):
+            year = None
+
+    # Build the URL — prefer explicit Spotify URL column, fall back to ID
+    url = None
+    if spotify_url and "open.spotify.com" in spotify_url:
+        url = spotify_url
+    elif song_id and len(song_id) >= 10:
+        url = _build_spotify_url(song_id)
+
+    if not url:
+        logger.debug(
+            "Row %d: No Spotify URL or ID for '%s - %s', skipping",
+            row_num,
+            artists[0],
+            track_name,
+        )
+        return None
+
+    # Create Song object with all available data
+    song = Song.from_missing_data(
+        name=track_name,
+        artists=artists,
+        artist=artists[0],
+        genres=genres,
+        album_name=album_name if album_name else None,
+        album_artist=artists[0],  # Best guess from CSV data
+        duration=duration_sec,
+        year=year,
+        date=release_date if release_date else None,
+        song_id=song_id if song_id else None,
+        explicit=None,  # Exportify doesn't export this
+        publisher=record_label if record_label else None,
+        url=url,
+        popularity=popularity,
+        isrc=None,  # Not in Exportify CSV
+        cover_url=None,  # Will be fetched when reinitializing
+    )
+
+    return song
+
+
+@dataclass(frozen=True)
+class CSVImport(SongList):
+    """
+    CSVImport class for handling songs loaded from Exportify CSV files.
+    Acts as a drop-in replacement for the Saved class when the API is unavailable.
+    """
+
+    @staticmethod
+    def get_metadata(url: str) -> Tuple[Dict[str, Any], List[Song]]:
+        """
+        Returns metadata for a CSV import.
+
+        ### Arguments
+        - url: Path to the CSV file (prefixed with "csv:" or raw path).
+
+        ### Returns
+        - metadata: A dictionary containing the metadata for the import.
+        - songs: A list of Song objects.
+        """
+        # Strip the "csv:" prefix if present
+        if url.startswith("csv:"):
+            file_path = Path(url[4:])
+        else:
+            file_path = Path(url)
+
+        return parse_csv_file(file_path)
+
+    @classmethod
+    def from_csv_path(
+        cls, csv_path: str, fetch_songs: bool = False
+    ) -> "CSVImport":
+        """
+        Create a CSVImport object directly from a file path.
+
+        ### Arguments
+        - csv_path: Path to the Exportify CSV file.
+        - fetch_songs: Whether to re-fetch song metadata from Spotify API.
+                       Default False since we want to avoid API calls.
+
+        ### Returns
+        - CSVImport object containing all songs from the CSV.
+        """
+        file_path = Path(csv_path)
+        metadata, songs = parse_csv_file(file_path)
+        urls = [song.url for song in songs if song.url]
+
+        if fetch_songs:
+            from spotdl.types.song import Song as SongClass
+
+            fetched = []
+            for song in songs:
+                try:
+                    if song.url:
+                        fetched.append(SongClass.from_url(song.url))
+                    else:
+                        fetched.append(song)
+                except Exception as exc:
+                    logger.warning(
+                        "Could not fetch metadata for %s: %s",
+                        song.display_name,
+                        exc,
+                    )
+                    fetched.append(song)
+            songs = fetched
+
+        return cls(**metadata, urls=urls, songs=songs)

--- a/spotdl/types/playlist.py
+++ b/spotdl/types/playlist.py
@@ -45,7 +45,26 @@ class Playlist(SongList):
 
         spotify_client = SpotifyClient()
 
-        playlist = spotify_client.playlist(url)
+        try:
+            playlist = spotify_client.playlist(url)
+        except Exception as exc:
+            exc_str = str(exc).lower()
+            if "403" in exc_str or "404" in exc_str or "forbidden" in exc_str or "not found" in exc_str:
+                logger.info(
+                    "Playlist could not be loaded with standard client (possibly private). "
+                    "Trying Exportify client..."
+                )
+                from spotdl.utils.exportify_auth import get_exportify_client
+                try:
+                    spotify_client = get_exportify_client()
+                    playlist = spotify_client.playlist(url)
+                except Exception as inner_exc:
+                    raise PlaylistError(
+                        f"Wrong playlist ID or URL (Exportify client also failed: {inner_exc})"
+                    ) from inner_exc
+            else:
+                raise PlaylistError(f"Failed to fetch playlist: {exc}") from exc
+
         if playlist is None:
             raise PlaylistError("Invalid playlist URL.")
 

--- a/spotdl/types/saved.py
+++ b/spotdl/types/saved.py
@@ -65,51 +65,18 @@ class Saved(SongList):
 
         metadata = {"name": "Saved tracks", "url": url}
 
-        spotify_client = SpotifyClient()
-        if spotify_client.user_auth is False:  # type: ignore
-            raise SavedError("You must be logged in to use this function")
+        from spotdl.utils.exportify_auth import get_exportify_client
 
         try:
+            logger.info("Initializing Spotify client with Exportify credentials...")
+            spotify_client = get_exportify_client()
             saved_tracks_response = spotify_client.current_user_saved_tracks()
         except Exception as exc:
-            exc_str = str(exc).lower()
-
-            # Catch HTTP 403 Forbidden — Premium required
-            if "403" in exc_str or "forbidden" in exc_str:
-                logger.error(EXPORTIFY_HELP_MESSAGE)
-                raise SavedError(
-                    "Spotify API returned 403 Forbidden when fetching saved tracks. "
-                    "This typically means the app owner's Spotify account does not "
-                    "have Premium. Use Exportify (https://exportify.net) to export "
-                    "your liked songs as a CSV, then run:\n\n"
-                    "    spotdl download --from-csv your_export.csv\n"
-                ) from exc
-
-            # Catch HTTP 401 Unauthorized — token expired or invalid
-            if "401" in exc_str or "unauthorized" in exc_str:
-                logger.error(
-                    "Spotify API returned 401 Unauthorized. "
-                    "Your auth token may have expired. Try logging in again "
-                    "with --user-auth, or use Exportify as a workaround."
-                )
-                raise SavedError(
-                    "Spotify API returned 401 Unauthorized. "
-                    "Try re-authenticating with --user-auth, or use:\n\n"
-                    "    spotdl download --from-csv your_export.csv\n"
-                ) from exc
-
-            # Re-raise other exceptions with helpful context
-            logger.error(
-                "Failed to fetch saved tracks from Spotify API: %s\n"
-                "If this persists, try using Exportify as a workaround:\n"
-                "    spotdl download --from-csv your_export.csv",
-                exc,
-            )
+            logger.error("Failed to authenticate or fetch saved tracks: %s", exc)
             raise SavedError(
                 f"Failed to fetch saved tracks: {exc}\n\n"
-                "If this error persists, use Exportify (https://exportify.net) "
-                "to export your liked songs, then run:\n\n"
-                "    spotdl download --from-csv your_export.csv\n"
+                "Please make sure you authorize the Exportify app in your browser "
+                "and copy/paste the redirection URL correctly."
             ) from exc
 
         if saved_tracks_response is None:

--- a/spotdl/types/saved.py
+++ b/spotdl/types/saved.py
@@ -2,6 +2,7 @@
 Saved module for handing the saved tracks from user library
 """
 
+import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List, Tuple
 
@@ -9,6 +10,27 @@ from spotdl.types.song import Song, SongList
 from spotdl.utils.spotify import SpotifyClient
 
 __all__ = ["Saved", "SavedError"]
+
+logger = logging.getLogger(__name__)
+
+EXPORTIFY_HELP_MESSAGE = """
+╔══════════════════════════════════════════════════════════════════════╗
+║  SPOTIFY API ERROR: Cannot fetch saved/liked tracks (HTTP 403)     ║
+║                                                                    ║
+║  This happens because Spotify's Web API requires the app owner     ║
+║  to have Spotify Premium to access /me/tracks.                     ║
+║                                                                    ║
+║  WORKAROUND — Use Exportify to export your liked songs:            ║
+║                                                                    ║
+║  1. Go to https://exportify.net                                    ║
+║  2. Log in with your Spotify account                               ║
+║  3. Export your "Liked Songs" playlist as a CSV file                ║
+║  4. Run: spotdl download --from-csv exported.csv                   ║
+║                                                                    ║
+║  This will download all your liked songs with full metadata,       ║
+║  no Premium required!                                              ║
+╚══════════════════════════════════════════════════════════════════════╝
+"""
 
 
 class SavedError(Exception):
@@ -34,6 +56,11 @@ class Saved(SongList):
         ### Returns
         - metadata: A dictionary containing the metadata for the saved list.
         - songs: A list of Song objects.
+
+        ### Raises
+        - SavedError: If the Spotify API returns 403 (Premium required) or
+          any other error. The error message includes instructions to use
+          Exportify as a workaround.
         """
 
         metadata = {"name": "Saved tracks", "url": url}
@@ -42,7 +69,49 @@ class Saved(SongList):
         if spotify_client.user_auth is False:  # type: ignore
             raise SavedError("You must be logged in to use this function")
 
-        saved_tracks_response = spotify_client.current_user_saved_tracks()
+        try:
+            saved_tracks_response = spotify_client.current_user_saved_tracks()
+        except Exception as exc:
+            exc_str = str(exc).lower()
+
+            # Catch HTTP 403 Forbidden — Premium required
+            if "403" in exc_str or "forbidden" in exc_str:
+                logger.error(EXPORTIFY_HELP_MESSAGE)
+                raise SavedError(
+                    "Spotify API returned 403 Forbidden when fetching saved tracks. "
+                    "This typically means the app owner's Spotify account does not "
+                    "have Premium. Use Exportify (https://exportify.net) to export "
+                    "your liked songs as a CSV, then run:\n\n"
+                    "    spotdl download --from-csv your_export.csv\n"
+                ) from exc
+
+            # Catch HTTP 401 Unauthorized — token expired or invalid
+            if "401" in exc_str or "unauthorized" in exc_str:
+                logger.error(
+                    "Spotify API returned 401 Unauthorized. "
+                    "Your auth token may have expired. Try logging in again "
+                    "with --user-auth, or use Exportify as a workaround."
+                )
+                raise SavedError(
+                    "Spotify API returned 401 Unauthorized. "
+                    "Try re-authenticating with --user-auth, or use:\n\n"
+                    "    spotdl download --from-csv your_export.csv\n"
+                ) from exc
+
+            # Re-raise other exceptions with helpful context
+            logger.error(
+                "Failed to fetch saved tracks from Spotify API: %s\n"
+                "If this persists, try using Exportify as a workaround:\n"
+                "    spotdl download --from-csv your_export.csv",
+                exc,
+            )
+            raise SavedError(
+                f"Failed to fetch saved tracks: {exc}\n\n"
+                "If this error persists, use Exportify (https://exportify.net) "
+                "to export your liked songs, then run:\n\n"
+                "    spotdl download --from-csv your_export.csv\n"
+            ) from exc
+
         if saved_tracks_response is None:
             raise SavedError("Couldn't get saved tracks")
 

--- a/spotdl/utils/arguments.py
+++ b/spotdl/utils/arguments.py
@@ -93,6 +93,7 @@ def parse_main_options(parser: _ArgumentGroup):
         is_web = False
 
     is_frozen = getattr(sys, "frozen", False)
+    has_from_csv = "--from-csv" in sys.argv
 
     # If the program is frozen, we and user didn't pass any arguments,
     # or if the user is using the web interface, we don't need to parse
@@ -105,6 +106,11 @@ def parse_main_options(parser: _ArgumentGroup):
             parser._remove_action(operation)  # pylint: disable=protected-access
 
         parser._remove_action(query)  # pylint: disable=protected-access
+
+    # If --from-csv is used, make query optional (nargs="*" instead of "+")
+    if has_from_csv:
+        query.nargs = "*"
+        query.default = []
 
     # Audio provider argument
     parser.add_argument(
@@ -160,6 +166,23 @@ def parse_main_options(parser: _ArgumentGroup):
         const=False,
         help="Disable filtering results.",
     )
+
+    # Add CSV import argument (Exportify workaround)
+    parser.add_argument(
+        "--from-csv",
+        dest="from_csv",
+        type=str,
+        help=(
+            "N|Path to an Exportify CSV file to import songs from.\n"
+            "This is a workaround for the Spotify API's /me/tracks endpoint\n"
+            "which requires Premium on the app owner's account.\n\n"
+            "Usage:\n"
+            "  1. Go to https://exportify.net\n"
+            "  2. Export your liked songs as CSV\n"
+            "  3. Run: spotdl download --from-csv exported.csv\n"
+        ),
+    )
+
 
     # Add use only verified results argument
     parser.add_argument(

--- a/spotdl/utils/exportify_auth.py
+++ b/spotdl/utils/exportify_auth.py
@@ -1,0 +1,73 @@
+"""
+Exportify Authentication module for spotDL.
+
+Bypasses Spotify Web API's 403 Forbidden limitations on Development Mode apps
+by using the public, production-approved Exportify Client ID with the PKCE flow.
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import spotipy
+from spotipy.cache_handler import CacheFileHandler
+from spotipy.oauth2 import SpotifyPKCE
+
+from spotdl.utils.config import get_spotdl_path
+
+logger = logging.getLogger(__name__)
+
+EXPORTIFY_CLIENT_ID = "9950ac751e34487dbbe027c4fd7f8e99"
+EXPORTIFY_REDIRECT_URI = "https://watsonbox.github.io/exportify/"
+EXPORTIFY_SCOPES = "user-library-read,playlist-read-private"
+
+
+def get_exportify_client() -> spotipy.Spotify:
+    """
+    Initializes and returns a Spotipy client authenticated via Exportify's Client ID.
+    If a valid token exists in the cache, it is reused and refreshed automatically.
+    Otherwise, the user is guided through the interactive browser login.
+    """
+    cache_path = get_spotdl_path() / ".spotipy_exportify"
+
+    # Ensure cache directory exists
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+    cache_handler = CacheFileHandler(cache_path=str(cache_path))
+
+    auth_manager = SpotifyPKCE(
+        client_id=EXPORTIFY_CLIENT_ID,
+        redirect_uri=EXPORTIFY_REDIRECT_URI,
+        scope=EXPORTIFY_SCOPES,
+        cache_handler=cache_handler,
+    )
+
+    # Check if token is already cached
+    token_info = auth_manager.get_cached_token()
+
+    if not token_info:
+        logger.warning(
+            "\n"
+            "┌────────────────────────────────────────────────────────┐\n"
+            "│  SPOTIFY AUTHENTICATION REQUIRED (via Exportify app)   │\n"
+            "│                                                        │\n"
+            "│  To access your saved/liked tracks, we need to log in  │\n"
+            "│  using Exportify's production-approved Spotify app.   │\n"
+            "│                                                        │\n"
+            "│  1. A browser window will open for Spotify login.      │\n"
+            "│  2. Log in and authorize access.                       │\n"
+            "│  3. You will be redirected to watsonbox.github.io.     │\n"
+            "│  4. Copy the entire redirect URL from your browser     │\n"
+            "│     address bar and paste it in the prompt below.      │\n"
+            "└────────────────────────────────────────────────────────┘\n"
+        )
+
+    try:
+        # Get the access token (opens browser and prompts if not cached/expired)
+        access_token = auth_manager.get_access_token(as_dict=False)
+    except Exception as exc:
+        logger.error("Failed to authenticate with Spotify PKCE: %s", exc)
+        raise exc
+
+    return spotipy.Spotify(auth=access_token)

--- a/spotdl/utils/exportify_auth.py
+++ b/spotdl/utils/exportify_auth.py
@@ -65,7 +65,7 @@ def get_exportify_client() -> spotipy.Spotify:
 
     try:
         # Get the access token (opens browser and prompts if not cached/expired)
-        access_token = auth_manager.get_access_token(as_dict=False)
+        access_token = auth_manager.get_access_token()
     except Exception as exc:
         logger.error("Failed to authenticate with Spotify PKCE: %s", exc)
         raise exc

--- a/spotdl/utils/search.py
+++ b/spotdl/utils/search.py
@@ -17,6 +17,7 @@ from ytmusicapi import YTMusic
 
 from spotdl.types.album import Album
 from spotdl.types.artist import Artist
+from spotdl.types.csv_import import CSVImport, CSVImportError
 from spotdl.types.playlist import Playlist
 from spotdl.types.saved import Saved
 from spotdl.types.song import Song, SongList
@@ -289,6 +290,21 @@ def get_simple_songs(
                 for track in json.load(save_file):
                     # Append to songs
                     songs.append(Song.from_dict(track))
+        elif request.endswith(".csv"):
+            # Handle Exportify CSV files
+            try:
+                csv_list = CSVImport.from_csv_path(request, fetch_songs=False)
+                lists.append(csv_list)
+                logger.info(
+                    "Loaded %d songs from CSV file: %s",
+                    csv_list.length,
+                    request,
+                )
+            except CSVImportError as exc:
+                logger.error("Failed to load CSV file '%s': %s", request, exc)
+                raise QueryError(
+                    f"Failed to load CSV file '{request}': {exc}"
+                ) from exc
         else:
             songs.append(Song.from_search_term(request))
 


### PR DESCRIPTION
# Title
<!--- Provide a general summary of your changes in the Title above -->
feat: Add Exportify Client ID PKCE auth fallback and CSV import workaround for saved/liked tracks

## Description
<!--- Describe your changes in detail -->
This Pull Request adds an Exportify-based PKCE authentication fallback to bypass the `403 Forbidden` API error returned when trying to fetch saved (liked) tracks or private playlists. It also introduces support for importing/downloading tracks from an Exportify CSV file export.

1. **Fallback Authentication (`spotdl/utils/exportify_auth.py`)**:
   - Implements Spotify PKCE authentication flow using Exportify's public, production-approved Spotify Client ID (`9950ac751e34487dbbe027c4fd7f8e99`).
   - Caches the authentication token (and `refresh_token`) locally in the spotDL settings directory (`~/.spotdl/.spotipy_exportify`).
   - Automatically refreshes the token on future runs, ensuring users only have to log in via browser once.
2. **Private Playlists Fallback (`spotdl/types/playlist.py`)**:
   - Automatically falls back to the Exportify client if a playlist fails to load (e.g. if it is private).
3. **Saved Tracks Flow (`spotdl/types/saved.py`)**:
   - Uses the Exportify PKCE authentication flow to retrieve the user's liked tracks.
4. **CSV Import Option (`spotdl/types/csv_import.py`)**:
   - Adds support for parsing CSV exports from Exportify (`--from-csv`), allowing users to completely bypass API access if they prefer manual exports.
5. **CLI User Auth bypass (`spotdl/console/entry_point.py`)**:
   - Removes the validation that requires the user to pass `--user-auth` when using the `saved` query, as the authorization now happens automatically and transparently on the first run.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves problems with the HTTP 403 Forbidden/Premium requirements when accessing saved/liked tracks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The Spotify `/me/tracks` endpoint currently requires the app owner's developer account to have Spotify Premium, and restricts requests on Sandbox/Development mode client IDs to explicit registered test users. Since the default client ID shared by spotDL is in Development mode, it returns `403 Forbidden` for most users when trying to access `/me/tracks`. This PR resolves those restrictions transparently.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested the interactive PKCE authorization flow on Windows using Python 3.10 with standard and non-premium Spotify accounts.
- Tested CSV imports with various Exportify CSV layouts, ensuring track metadata, artists, album names, durations, and URLs are parsed correctly and successfully converted to `Song` objects for downloading.
- Verified `--from-csv` command line argument functionality.

## Screenshots (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
