### PR TITLE
Fix Bandcamp and Piped provider failures

### DIFF
--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -704,14 +704,9 @@ class Downloader:
             # Copy the downloaded file to the output file
             # if the temp file and output file have the same extension
             # and the bitrate is set to auto or disable
-            # Don't copy if the audio provider is piped
-            # unless the bitrate is set to disable
             if (
                 self.settings["bitrate"] in ["auto", "disable", None]
                 and temp_file.suffix == output_file.suffix
-            ) and not (
-                self.settings["audio_providers"][0] == "piped"
-                and self.settings["bitrate"] != "disable"
             ):
                 shutil.move(str(temp_file), output_file)
                 success = True

--- a/spotdl/providers/audio/bandcamp.py
+++ b/spotdl/providers/audio/bandcamp.py
@@ -101,7 +101,12 @@ class BandCampTrack:
                 lyrics = rjson["lyrics"]
                 if isinstance(lyrics, Mapping):
                     self.lyrics = lyrics.get(str(self.track_id)) or ""
-            except (requests.RequestException, JSONDecodeError, KeyError, TypeError):
+            except (
+                requests.RequestException,
+                JSONDecodeError,
+                KeyError,
+                TypeError,
+            ):
                 self.lyrics = ""
 
         self.is_price_set = result.get("is_set_price")

--- a/spotdl/providers/audio/bandcamp.py
+++ b/spotdl/providers/audio/bandcamp.py
@@ -106,7 +106,12 @@ class BandCampTrack:
                 JSONDecodeError,
                 KeyError,
                 TypeError,
-            ):
+            ) as exc:
+                logger.debug(
+                    "Failed to get lyrics for BandCamp track %s: %s",
+                    self.track_id,
+                    exc,
+                )
                 self.lyrics = ""
 
         self.is_price_set = result.get("is_set_price")
@@ -168,7 +173,8 @@ def search(search_string: str = ""):
             proxies=GlobalConfig.get_parameter("proxies"),
         )
         results = response.json()["results"]
-    except (requests.RequestException, JSONDecodeError, KeyError, TypeError):
+    except (requests.RequestException, JSONDecodeError, KeyError, TypeError) as exc:
+        logger.debug("BandCamp search failed for query %s: %s", search_string, exc)
         return []
 
     return_results: List[Tuple[str, str]] = []
@@ -224,7 +230,8 @@ class BandCamp(AudioProvider):
                 IndexError,
                 TypeError,
                 ValueError,
-            ):
+            ) as exc:
+                logger.debug("Failed to get BandCamp track %s: %s", result, exc)
                 continue
 
             if not all(

--- a/spotdl/providers/audio/bandcamp.py
+++ b/spotdl/providers/audio/bandcamp.py
@@ -100,7 +100,7 @@ class BandCampTrack:
                 rjson = resp.json()
                 lyrics = rjson["lyrics"]
                 if isinstance(lyrics, Mapping):
-                    self.lyrics = lyrics.get(str(self.track_id), "")
+                    self.lyrics = lyrics.get(str(self.track_id)) or ""
             except (requests.RequestException, JSONDecodeError, KeyError, TypeError):
                 self.lyrics = ""
 
@@ -120,7 +120,7 @@ class BandCampTrack:
                 if isinstance(tag, Mapping) and "name" in tag:
                     self.tags.append(tag["name"])
 
-        self.art_id = result.get("art_id", 0)
+        self.art_id = result.get("art_id") or 0
         self.art_url = "https://f4.bcbits.com/img/a" + str(self.art_id) + "_0.jpg"
 
         self.artist_id = result["band"]["band_id"]
@@ -129,13 +129,13 @@ class BandCampTrack:
         self.album_id = result["album_id"]
         self.album_title = result["album_title"]
 
-        self.label_id = result.get("label_id", 0)
-        self.label_title = result.get("label", "")
+        self.label_id = result.get("label_id") or 0
+        self.label_title = result.get("label") or ""
 
-        self.about = result.get("about", "")
-        self.credits = result.get("credits", "")
+        self.about = result.get("about") or ""
+        self.credits = result.get("credits") or ""
 
-        self.date_released_unix = result.get("release_date", 0)
+        self.date_released_unix = result.get("release_date") or 0
 
         self.track_url = result["bandcamp_url"]
 

--- a/spotdl/providers/audio/bandcamp.py
+++ b/spotdl/providers/audio/bandcamp.py
@@ -204,8 +204,6 @@ class BandCamp(AudioProvider):
 
         try:
             results = search(search_term)
-        except KeyError:
-            return []
         except Exception as exc:
             logger.error("Failed to get results from BandCamp", exc_info=exc)
             return []

--- a/spotdl/providers/audio/bandcamp.py
+++ b/spotdl/providers/audio/bandcamp.py
@@ -3,9 +3,11 @@ BandCamp module for downloading and searching songs.
 """
 
 import logging
+from collections.abc import Mapping
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
+from requests.exceptions import JSONDecodeError
 
 from spotdl.providers.audio.base import AudioProvider
 from spotdl.types.result import Result
@@ -87,27 +89,38 @@ class BandCampTrack:
 
         # getting lyrics, if there is any
         if self.has_lyrics is True:
-            resp = requests.get(
-                "https://bandcamp.com/api/mobile/25/tralbum_lyrics?tralbum_id="
-                + str(self.track_id)
-                + "&tralbum_type=t",
-                timeout=10,
-                proxies=GlobalConfig.get_parameter("proxies"),
-            )
-            rjson = resp.json()
-            self.lyrics = rjson["lyrics"][str(self.track_id)]
+            try:
+                resp = requests.get(
+                    "https://bandcamp.com/api/mobile/25/tralbum_lyrics?tralbum_id="
+                    + str(self.track_id)
+                    + "&tralbum_type=t",
+                    timeout=10,
+                    proxies=GlobalConfig.get_parameter("proxies"),
+                )
+                rjson = resp.json()
+                lyrics = rjson["lyrics"]
+                if isinstance(lyrics, Mapping):
+                    self.lyrics = lyrics.get(str(self.track_id), "")
+            except (requests.RequestException, JSONDecodeError, KeyError, TypeError):
+                self.lyrics = ""
 
-        self.is_price_set = result["is_set_price"]
-        self.price = {"currency": result["currency"], "amount": result["price"]}
-        self.require_email = result["require_email"]
-        self.is_purchasable = result["is_purchasable"]
-        self.is_free = result["free_download"]
-        self.is_preorder = result["is_preorder"]
+        self.is_price_set = result.get("is_set_price")
+        self.price = {
+            "currency": result.get("currency"),
+            "amount": result.get("price"),
+        }
+        self.require_email = result.get("require_email")
+        self.is_purchasable = result.get("is_purchasable")
+        self.is_free = result.get("free_download")
+        self.is_preorder = result.get("is_preorder")
 
-        for tag in result["tags"]:
-            self.tags.append(tag["name"])
+        tags = result.get("tags", [])
+        if isinstance(tags, list):
+            for tag in tags:
+                if isinstance(tag, Mapping) and "name" in tag:
+                    self.tags.append(tag["name"])
 
-        self.art_id = result["art_id"]
+        self.art_id = result.get("art_id", 0)
         self.art_url = "https://f4.bcbits.com/img/a" + str(self.art_id) + "_0.jpg"
 
         self.artist_id = result["band"]["band_id"]
@@ -116,13 +129,13 @@ class BandCampTrack:
         self.album_id = result["album_id"]
         self.album_title = result["album_title"]
 
-        self.label_id = result["label_id"]
-        self.label_title = result["label"]
+        self.label_id = result.get("label_id", 0)
+        self.label_title = result.get("label", "")
 
-        self.about = result["about"]
-        self.credits = result["credits"]
+        self.about = result.get("about", "")
+        self.credits = result.get("credits", "")
 
-        self.date_released_unix = result["release_date"]
+        self.date_released_unix = result.get("release_date", 0)
 
         self.track_url = result["bandcamp_url"]
 
@@ -141,21 +154,29 @@ def search(search_string: str = ""):
     - A list of artist and track ids if found
     """
 
-    response = requests.get(
-        "https://bandcamp.com/api/fuzzysearch/2/app_autocomplete?q="
-        + search_string
-        + "&param_with_locations=true",
-        timeout=10,
-        proxies=GlobalConfig.get_parameter("proxies"),
-    )
-
-    results = response.json()["results"]
+    try:
+        response = requests.get(
+            "https://bandcamp.com/api/fuzzysearch/2/app_autocomplete?q="
+            + search_string
+            + "&param_with_locations=true",
+            timeout=10,
+            proxies=GlobalConfig.get_parameter("proxies"),
+        )
+        results = response.json()["results"]
+    except (requests.RequestException, JSONDecodeError, KeyError, TypeError):
+        return []
 
     return_results: List[Tuple[str, str]] = []
 
     for item in results:
-        if item["type"] == "t":
-            return_results.append((item["band_id"], item["id"]))
+        if not isinstance(item, Mapping):
+            continue
+
+        if item.get("type") == "t":
+            try:
+                return_results.append((item["band_id"], item["id"]))
+            except KeyError:
+                continue
 
     return return_results
 
@@ -191,7 +212,26 @@ class BandCamp(AudioProvider):
 
         simplified_results: List[Result] = []
         for result in results:
-            track = BandCampTrack(int(result[0]), int(result[1]))
+            try:
+                track = BandCampTrack(int(result[0]), int(result[1]))
+            except (
+                requests.RequestException,
+                JSONDecodeError,
+                KeyError,
+                IndexError,
+                TypeError,
+                ValueError,
+            ):
+                continue
+
+            if not all(
+                isinstance(value, str)
+                for value in (track.track_url, track.track_title, track.artist_title)
+            ):
+                continue
+
+            if not isinstance(track.track_duration_seconds, (int, float)):
+                continue
 
             simplified_results.append(
                 Result(

--- a/spotdl/providers/audio/piped.py
+++ b/spotdl/providers/audio/piped.py
@@ -2,6 +2,7 @@
 Piped module for downloading and searching songs.
 """
 
+import logging
 from collections.abc import Mapping
 from typing import Any, Dict, List, Optional
 from urllib.parse import parse_qs, urlparse
@@ -14,6 +15,7 @@ from spotdl.types.result import Result
 from spotdl.utils.config import GlobalConfig
 
 __all__ = ["Piped"]
+logger = logging.getLogger(__name__)
 
 HEADERS = {
     "accept": "*/*",
@@ -104,22 +106,35 @@ class Piped(AudioProvider):
                 proxies=GlobalConfig.get_parameter("proxies"),
                 timeout=20,
             )
-        except requests.RequestException:
+        except requests.RequestException as exc:
+            logger.debug("Piped search failed for query %s: %s", search_term, exc)
             return []
 
         if response.status_code != 200:
+            logger.debug(
+                "Piped search for query %s returned status code %s",
+                search_term,
+                response.status_code,
+            )
             return []
 
         try:
             search_results = response.json()
         except JSONDecodeError:
+            logger.debug("Piped search for query %s returned invalid JSON", search_term)
             return []
 
         if not isinstance(search_results, Mapping):
+            logger.debug(
+                "Piped search for query %s returned a malformed response", search_term
+            )
             return []
 
         items = search_results.get("items", [])
         if not isinstance(items, list):
+            logger.debug(
+                "Piped search for query %s returned a malformed response", search_term
+            )
             return []
 
         results = []

--- a/spotdl/providers/audio/piped.py
+++ b/spotdl/providers/audio/piped.py
@@ -24,6 +24,21 @@ HEADERS = {
 API_BASE_URL = "https://api.piped.private.coffee"
 
 
+def _legacy_piped_watch_url_to_youtube(url: str) -> str:
+    parsed_url = urlparse(url)
+    if parsed_url.hostname not in {"piped.video", "www.piped.video"}:
+        return url
+
+    if parsed_url.path != "/watch":
+        return url
+
+    video_ids = parse_qs(parsed_url.query).get("v")
+    if not video_ids:
+        return url
+
+    return f"https://www.youtube.com/watch?v={video_ids[0]}"
+
+
 class Piped(AudioProvider):
     """
     YouTube Music audio provider class
@@ -182,4 +197,6 @@ class Piped(AudioProvider):
             if proxy:
                 self.audio_handler.params["proxy"] = proxy
 
-        return super().get_download_metadata(url, download)
+        return super().get_download_metadata(
+            _legacy_piped_watch_url_to_youtube(url), download
+        )

--- a/spotdl/providers/audio/piped.py
+++ b/spotdl/providers/audio/piped.py
@@ -2,30 +2,26 @@
 Piped module for downloading and searching songs.
 """
 
-import logging
-import shlex
+from collections.abc import Mapping
 from typing import Any, Dict, List, Optional
+from urllib.parse import parse_qs, urlparse
 
 import requests
-from yt_dlp import YoutubeDL
+from requests.exceptions import JSONDecodeError
 
 from spotdl.providers.audio.base import (
     ISRC_REGEX,
     AudioProvider,
-    AudioProviderError,
-    YTDLLogger,
 )
 from spotdl.types.result import Result
-from spotdl.utils.config import GlobalConfig, get_temp_path
-from spotdl.utils.deno import get_local_deno_yt_dlp_options, warn_if_deno_missing
-from spotdl.utils.formatter import args_to_ytdlp_options
+from spotdl.utils.config import GlobalConfig
 
 __all__ = ["Piped"]
-logger = logging.getLogger(__name__)
 
 HEADERS = {
     "accept": "*/*",
 }
+API_BASE_URL = "https://api.piped.private.coffee"
 
 
 class Piped(AudioProvider):
@@ -39,7 +35,7 @@ class Piped(AudioProvider):
         {"filter": "music_videos"},
     ]
 
-    def __init__(  # pylint: disable=super-init-not-called
+    def __init__(  # pylint: disable=too-many-positional-arguments
         self,
         output_format: str = "mp3",
         cookie_file: Optional[str] = None,
@@ -58,37 +54,13 @@ class Piped(AudioProvider):
         - filter_results: Whether to filter results.
         """
 
-        self.output_format = output_format
-        self.cookie_file = cookie_file
-        self.search_query = search_query
-        self.filter_results = filter_results
-
-        if self.output_format == "m4a":
-            ytdl_format = "best[ext=m4a]/best"
-        elif self.output_format == "opus":
-            ytdl_format = "best[ext=webm]/best"
-        else:
-            ytdl_format = "best"
-
-        yt_dlp_options = {
-            "format": ytdl_format,
-            "quiet": True,
-            "no_warnings": True,
-            "encoding": "UTF-8",
-            "logger": YTDLLogger(),
-            "cookiefile": self.cookie_file,
-            "outtmpl": f"{get_temp_path()}/%(id)s.%(ext)s",
-            "retries": 5,
-        }
-
-        yt_dlp_options.update(get_local_deno_yt_dlp_options())
-
-        if yt_dlp_args:
-            yt_dlp_options = args_to_ytdlp_options(
-                shlex.split(yt_dlp_args), yt_dlp_options
-            )
-
-        self.audio_handler = YoutubeDL(yt_dlp_options)
+        super().__init__(
+            output_format=output_format,
+            cookie_file=cookie_file,
+            search_query=search_query,
+            filter_results=filter_results,
+            yt_dlp_args=yt_dlp_args,
+        )
         self.session = requests.Session()
 
     def get_results(self, search_term: str, **kwargs) -> List[Result]:
@@ -106,48 +78,88 @@ class Piped(AudioProvider):
         if kwargs is None:
             kwargs = {}
 
+        isrc_result = ISRC_REGEX.search(search_term)
+
         params = {"q": search_term, **kwargs}
         if params.get("filter") is None:
-            params["filter"] = "music_videos"
+            params["filter"] = "music_songs" if isrc_result else "music_videos"
 
-        response = self.session.get(
-            "https://piped.video/search",
-            params=params,
-            headers=HEADERS,
-            timeout=20,
-        )
+        try:
+            response = self.session.get(
+                f"{API_BASE_URL}/search",
+                params=params,
+                headers=HEADERS,
+                proxies=GlobalConfig.get_parameter("proxies"),
+                timeout=20,
+            )
+        except requests.RequestException:
+            return []
 
         if response.status_code != 200:
-            raise AudioProviderError(
-                f"Failed to get results for {search_term} from Piped: {response.text}"
-            )
+            return []
 
-        search_results = response.json()
+        try:
+            search_results = response.json()
+        except JSONDecodeError:
+            return []
 
-        # Simplify results
+        if not isinstance(search_results, Mapping):
+            return []
+
+        items = search_results.get("items", [])
+        if not isinstance(items, list):
+            return []
+
         results = []
-        for result in search_results["items"]:
-            if result["type"] != "stream":
+        for result in items:
+            if not isinstance(result, Mapping):
                 continue
 
-            isrc_result = ISRC_REGEX.search(search_term)
+            if result.get("type") != "stream":
+                continue
+
+            try:
+                result_url = result["url"]
+                title = result["title"]
+                duration = result["duration"]
+                uploader_name = result["uploaderName"]
+            except KeyError:
+                continue
+
+            if not all(
+                isinstance(value, str) for value in (result_url, title, uploader_name)
+            ):
+                continue
+
+            if not isinstance(duration, (int, float)):
+                continue
+
+            result_id = parse_qs(urlparse(result_url).query).get("v")
+            if result_id is None:
+                continue
+
+            views = result.get("views")
+            if views is not None:
+                try:
+                    views = int(views)
+                except (TypeError, ValueError):
+                    views = None
 
             results.append(
                 Result(
                     source="piped",
-                    url=f"https://piped.video{result['url']}",
-                    verified=kwargs.get("filter") == "music_songs",
-                    name=result["title"],
-                    duration=result["duration"],
-                    author=result["uploaderName"],
-                    result_id=result["url"].split("?v=")[1],
+                    url=f"https://www.youtube.com/watch?v={result_id[0]}",
+                    verified=params["filter"] == "music_songs",
+                    name=title,
+                    duration=duration,
+                    author=uploader_name,
+                    result_id=result_id[0],
                     artists=(
-                        (result["uploaderName"],)
-                        if kwargs.get("filter") == "music_songs"
-                        else None
+                        (uploader_name,) if params["filter"] == "music_songs" else None
                     ),
                     isrc_search=isrc_result is not None,
                     search_query=search_term,
+                    views=views,
                 )
             )
 
@@ -164,45 +176,10 @@ class Piped(AudioProvider):
         - A dictionary containing the metadata.
         """
 
-        url_id = url.split("?v=")[1]
-        piped_response = requests.get(
-            f"https://piped.video/streams/{url_id}",
-            timeout=10,
-            proxies=GlobalConfig.get_parameter("proxies"),
-        )
+        proxies = GlobalConfig.get_parameter("proxies")
+        if proxies:
+            proxy = proxies.get("https") or proxies.get("http")
+            if proxy:
+                self.audio_handler.params["proxy"] = proxy
 
-        if piped_response.status_code != 200:
-            raise AudioProviderError(
-                f"Failed to get metadata for {url} from Piped: {piped_response.text}"
-            )
-
-        piped_data = piped_response.json()
-
-        yt_dlp_json = {
-            "title": piped_data["title"],
-            "id": url_id,
-            "view_count": piped_data["views"],
-            "extractor": "Generic",
-            "formats": [],
-        }
-
-        for audio_stream in piped_data["audioStreams"]:
-            yt_dlp_json["formats"].append(
-                {
-                    "url": audio_stream["url"],
-                    "ext": "webm" if audio_stream["codec"] == "opus" else "m4a",
-                    "abr": audio_stream["quality"].split(" ")[0],
-                    "filesize": audio_stream["contentLength"],
-                }
-            )
-
-        try:
-            return self.audio_handler.process_video_result(
-                yt_dlp_json, download=download
-            )
-        except Exception as exception:
-            if download:
-                warn_if_deno_missing()
-
-            logger.debug(exception)
-            raise AudioProviderError(f"YT-DLP download error - {url}") from exception
+        return super().get_download_metadata(url, download)

--- a/spotdl/providers/audio/piped.py
+++ b/spotdl/providers/audio/piped.py
@@ -9,10 +9,7 @@ from urllib.parse import parse_qs, urlparse
 import requests
 from requests.exceptions import JSONDecodeError
 
-from spotdl.providers.audio.base import (
-    ISRC_REGEX,
-    AudioProvider,
-)
+from spotdl.providers.audio.base import ISRC_REGEX, AudioProvider
 from spotdl.types.result import Result
 from spotdl.utils.config import GlobalConfig
 

--- a/tests/providers/audio/test_bandcamp_piped.py
+++ b/tests/providers/audio/test_bandcamp_piped.py
@@ -1,0 +1,304 @@
+from requests.exceptions import ConnectionError, JSONDecodeError
+
+from spotdl.providers.audio import bandcamp
+from spotdl.providers.audio.piped import API_BASE_URL, Piped
+from spotdl.utils.config import GlobalConfig
+
+
+class JsonResponse:
+    def __init__(self, payload=None, status_code=200, invalid_json=False):
+        self.payload = payload
+        self.status_code = status_code
+        self.invalid_json = invalid_json
+        self.text = "<html>not json</html>" if invalid_json else ""
+
+    def json(self):
+        if self.invalid_json:
+            raise JSONDecodeError("Expecting value", self.text, 0)
+
+        return self.payload
+
+
+class StaticSession:
+    requested_url = None
+    params = None
+    proxies = None
+
+    def __init__(self, responses):
+        self.responses = iter(responses)
+
+    def get(self, *args, **kwargs):
+        self.requested_url = args[0]
+        self.params = kwargs.get("params")
+        self.proxies = kwargs.get("proxies")
+        response = next(self.responses)
+        if isinstance(response, Exception):
+            raise response
+
+        return response
+
+
+def bandcamp_track_payload(**overrides):
+    payload = {
+        "id": 2,
+        "title": "Test Track",
+        "tracks": [
+            {
+                "track_num": 1,
+                "duration": 123,
+                "is_streamable": True,
+                "has_lyrics": True,
+            }
+        ],
+        "is_set_price": False,
+        "currency": "USD",
+        "price": 0,
+        "require_email": False,
+        "is_purchasable": False,
+        "free_download": False,
+        "is_preorder": False,
+        "tags": [],
+        "art_id": 10,
+        "band": {
+            "band_id": 1,
+            "name": "Test Artist",
+        },
+        "album_id": 3,
+        "album_title": "Test Album",
+        "label_id": 4,
+        "label": "Test Label",
+        "about": "",
+        "credits": "",
+        "release_date": 0,
+        "bandcamp_url": "https://artist.bandcamp.com/track/test-track",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def malformed_optional_bandcamp_payload():
+    payload = bandcamp_track_payload(tags=None)
+    for key in ("label_id", "label", "about", "credits", "release_date"):
+        payload.pop(key)
+
+    return payload
+
+
+def install_bandcamp_get(monkeypatch, responses):
+    responses_iter = iter(responses)
+
+    def fake_get(*_args, **_kwargs):
+        response = next(responses_iter)
+        if isinstance(response, Exception):
+            raise response
+
+        return response
+
+    monkeypatch.setattr(bandcamp.requests, "get", fake_get)
+
+
+def piped_search_payload(items=None):
+    return {
+        "items": (
+            items
+            if items is not None
+            else [
+                {
+                    "type": "channel",
+                    "name": "Not a stream",
+                },
+                {
+                    "name": "Missing type",
+                },
+                {
+                    "type": "stream",
+                    "url": "/watch?v=video_id",
+                    "title": "Test Title",
+                    "duration": 123,
+                    "uploaderName": "Test Artist",
+                    "views": 12345,
+                },
+            ]
+        )
+    }
+
+
+def make_piped_provider(session):
+    provider = Piped.__new__(Piped)
+    provider.session = session
+    return provider
+
+
+def test_bandcamp_search_handles_invalid_json_and_malformed_rows(monkeypatch):
+    monkeypatch.setattr(
+        bandcamp.requests,
+        "get",
+        lambda *_args, **_kwargs: JsonResponse(invalid_json=True),
+    )
+
+    assert bandcamp.search("artist title") == []
+
+    monkeypatch.setattr(
+        bandcamp.requests,
+        "get",
+        lambda *_args, **_kwargs: JsonResponse(
+            {
+                "results": [
+                    {"type": "t", "band_id": "1", "id": "2"},
+                    {"type": "t", "id": "missing-band-id"},
+                    None,
+                    "not-a-row",
+                    {"type": "t", "band_id": "3", "id": "4"},
+                ]
+            }
+        ),
+    )
+
+    assert bandcamp.search("artist title") == [("1", "2"), ("3", "4")]
+
+
+def test_bandcamp_get_results_handles_bad_candidates_and_optional_data(monkeypatch):
+    skipped_cases = [
+        ([("1", "2")], [JsonResponse(invalid_json=True)]),
+        ([("1", "2")], [ConnectionError("failed")]),
+        ([("1", "2")], [JsonResponse({"id": 2})]),
+        ([("not-an-id", "2")], []),
+        (
+            [("1", "2")],
+            [
+                JsonResponse(bandcamp_track_payload(title=None)),
+                JsonResponse(invalid_json=True),
+            ],
+        ),
+    ]
+
+    for found_tracks, responses in skipped_cases:
+        monkeypatch.setattr(bandcamp, "search", lambda _term, ft=found_tracks: ft)
+        install_bandcamp_get(monkeypatch, responses)
+
+        assert bandcamp.BandCamp().get_results("artist title") == []
+
+    kept_cases = [
+        [
+            JsonResponse(bandcamp_track_payload()),
+            JsonResponse(invalid_json=True),
+        ],
+        [
+            JsonResponse(malformed_optional_bandcamp_payload()),
+            JsonResponse({"lyrics": []}),
+        ],
+    ]
+
+    monkeypatch.setattr(bandcamp, "search", lambda _term: [("1", "2")])
+
+    for responses in kept_cases:
+        install_bandcamp_get(monkeypatch, responses)
+
+        results = bandcamp.BandCamp().get_results("artist title")
+
+        assert len(results) == 1
+        assert results[0].url == "https://artist.bandcamp.com/track/test-track"
+
+
+def test_piped_get_results_handles_failed_api_responses_and_malformed_rows():
+    cases = [
+        [JsonResponse(invalid_json=True)],
+        [JsonResponse(status_code=502)],
+        [ConnectionError("failed")],
+        [JsonResponse({"error": "upstream failed"})],
+    ]
+
+    for responses in cases:
+        session = StaticSession(responses)
+        provider = make_piped_provider(session)
+
+        assert provider.get_results("artist title") == []
+        assert session.requested_url == f"{API_BASE_URL}/search"
+
+    session = StaticSession(
+        [
+            JsonResponse(
+                piped_search_payload(
+                    [
+                        {
+                            "type": "stream",
+                            "url": "/watch?missing=video_id",
+                            "title": "Missing Video ID",
+                            "duration": 123,
+                            "uploaderName": "Test Artist",
+                        },
+                        {
+                            "type": "stream",
+                            "url": None,
+                            "title": "Bad URL",
+                            "duration": 123,
+                            "uploaderName": "Test Artist",
+                        },
+                        {
+                            "type": "stream",
+                            "url": "/watch?v=bad_duration",
+                            "title": "Bad Duration",
+                            "duration": "123",
+                            "uploaderName": "Test Artist",
+                        },
+                        {
+                            "type": "stream",
+                            "url": "/watch?v=video_id",
+                            "title": "Test Title",
+                            "duration": 123,
+                            "uploaderName": "Test Artist",
+                        },
+                    ]
+                )
+            )
+        ]
+    )
+    provider = make_piped_provider(session)
+
+    results = provider.get_results("artist title")
+
+    assert [result.result_id for result in results] == ["video_id"]
+
+
+def test_piped_get_results_uses_api_proxy_isrc_and_canonical_youtube_url():
+    session = StaticSession([JsonResponse(piped_search_payload())])
+    provider = make_piped_provider(session)
+    proxies = {"http": "http://127.0.0.1:8080", "https": "http://127.0.0.1:8080"}
+    GlobalConfig.set_parameter("proxies", proxies)
+
+    try:
+        results = provider.get_results("USRC17607839")
+    finally:
+        GlobalConfig.set_parameter("proxies", None)
+
+    assert session.requested_url == f"{API_BASE_URL}/search"
+    assert session.params["filter"] == "music_songs"
+    assert session.proxies == proxies
+    assert results[0].url == "https://www.youtube.com/watch?v=video_id"
+    assert results[0].views == 12345
+    assert results[0].verified is True
+
+
+def test_piped_get_download_metadata_delegates_to_yt_dlp_with_proxy(mocker):
+    get = mocker.patch("spotdl.providers.audio.piped.requests.get")
+    provider = Piped.__new__(Piped)
+    provider.audio_handler = mocker.Mock()
+    provider.audio_handler.params = {}
+    provider.audio_handler.extract_info.return_value = {"id": "video_id"}
+    proxies = {"http": "http://127.0.0.1:8080", "https": "http://127.0.0.1:8080"}
+    GlobalConfig.set_parameter("proxies", proxies)
+
+    try:
+        metadata = provider.get_download_metadata(
+            "https://www.youtube.com/watch?v=video_id"
+        )
+    finally:
+        GlobalConfig.set_parameter("proxies", None)
+
+    get.assert_not_called()
+    assert metadata == {"id": "video_id"}
+    assert provider.audio_handler.params["proxy"] == proxies["https"]
+    provider.audio_handler.extract_info.assert_called_once_with(
+        "https://www.youtube.com/watch?v=video_id",
+        download=False,
+    )

--- a/tests/utils/test_deno.py
+++ b/tests/utils/test_deno.py
@@ -175,6 +175,7 @@ def test_piped_uses_local_deno_yt_dlp_options(monkeypatch, tmp_path):
     Test Piped passes spotDL's local Deno options to yt-dlp.
     """
 
+    from spotdl.providers.audio import base
     from spotdl.providers.audio import piped
 
     captured_options = {}
@@ -183,10 +184,10 @@ def test_piped_uses_local_deno_yt_dlp_options(monkeypatch, tmp_path):
         captured_options.update(options)
         return object()
 
-    monkeypatch.setattr(piped, "YoutubeDL", mock_youtube_dl)
-    monkeypatch.setattr(piped, "get_temp_path", lambda *_: tmp_path)
+    monkeypatch.setattr(base, "YoutubeDL", mock_youtube_dl)
+    monkeypatch.setattr(base, "get_temp_path", lambda *_: tmp_path)
     monkeypatch.setattr(
-        piped,
+        base,
         "get_local_deno_yt_dlp_options",
         lambda *_: {"js_runtimes": {"deno": {"path": "local-deno"}}},
     )


### PR DESCRIPTION
Fixes #2192

## Summary
- handle malformed Bandcamp responses without raw JSON errors
- use the Piped API for search and return YouTube watch URLs
- delegate Piped metadata/downloads to the existing yt-dlp path
- normalize saved legacy Piped watch URLs before yt-dlp
- remove the old Piped-specific copy/conversion exception
- treat ISRC searches as `music_songs` and mark those results verified, so a lone verified ISRC match is returned immediately (same semantics as the YTMusic provider)
- fall back to defaults when Bandcamp sends explicit JSON nulls, not just missing keys
- log swallowed provider errors at debug level instead of failing silently

## Rationale
Bandcamp was failing while parsing provider responses, so the error handling belongs in the Bandcamp provider.

Piped now only handles discovery. Metadata and downloads go through the existing yt-dlp path using YouTube watch URLs. Saved `piped.video/watch?v=...` URLs are normalized before delegation so older metadata still follows that path.

## Verification
- `uv run --python 3.14 pytest tests/providers/audio/test_bandcamp_piped.py tests/utils/test_deno.py -q`
- `uv run --python 3.14 black --check spotdl/providers/audio/bandcamp.py spotdl/providers/audio/piped.py spotdl/download/downloader.py tests/providers/audio/test_bandcamp_piped.py tests/utils/test_deno.py`
- `uv run --python 3.14 python -m py_compile spotdl/providers/audio/bandcamp.py spotdl/providers/audio/piped.py spotdl/download/downloader.py tests/providers/audio/test_bandcamp_piped.py tests/utils/test_deno.py`
- `uv run --python 3.14 pytest tests/providers/audio/test_youtube.py tests/providers/audio/test_ytmusic.py::test_ytm_get_results_retries_with_new_client -q`
- `uv run spotdl download "sewerslvt - whatever" --audio piped --bitrate disable --output "/tmp/spotdl-smoke/{artists} - {title}.{output-ext}"`
