### PR TITLE
Fix web UI playlist/album downloads and improve Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,33 @@
+# Version control
 .git
 .github
+
+# Editor / IDE
 .vscode
+.idea
+
+# Python artefacts
+.venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.egg-info
+dist
+build
+.pytest_cache
+.mypy_cache
+.ruff_cache
+
+# Project-specific build outputs
+spotdl.egg-info
+
+# Host-specific runtime files — must NOT land in the image
+config.json
+spotdl.log
+Music
+
+# Docs and test code not needed in the image
 docs
 scripts
 tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-alpine
+FROM python:3.13-slim-bookworm
 
 LABEL maintainer="Silverarmor"
 
@@ -7,39 +7,50 @@ LABEL maintainer="Silverarmor"
 ARG UID=1000
 ARG GID=1000
 
-# Install dependencies
-RUN apk add --no-cache \
-    ca-certificates \
-    ffmpeg \
-    openssl \
-    aria2 \
-    g++ \
-    git \
-    py3-cffi \
-    libffi-dev \
-    zlib-dev
+# Install uv from its official image (no pip install needed)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
-# Install uv and update pip/wheel
-RUN pip install --upgrade pip uv wheel spotipy
+# Deno is required by yt-dlp for some YouTube "made for kids" downloads
+COPY --from=denoland/deno:bin /deno /usr/local/bin/deno
+
+# Runtime dependencies. build-essential/libffi-dev are only needed to compile
+# native wheels during `uv sync`, so we purge them in the same layer.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        ffmpeg \
+        openssl \
+        aria2 \
+        build-essential \
+        libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Create spotdl user and group
-RUN addgroup -g $GID spotdl && \
-    adduser -D -u $UID -G spotdl spotdl
+RUN groupadd -g "$GID" spotdl \
+    && useradd -u "$UID" -g spotdl -m spotdl
 
 # Set workdir
 WORKDIR /app
 
-# Copy requirements files
-COPY . .
+# Copy ONLY what the build needs (nothing host-specific like .venv/config.json).
+# Listing files explicitly keeps the build reproducible from a clean git clone.
+COPY pyproject.toml uv.lock README.md ./
+COPY spotdl/ ./spotdl/
 
-# Install spotdl requirements
-RUN uv sync --no-dev
+# Install dependencies + project into /app/.venv, then drop the build toolchain
+RUN uv sync --no-dev --frozen \
+    && apt-get purge -y build-essential libffi-dev \
+    && apt-get autoremove -y
 
-# Fix permissions for the app dir
-RUN chown -R spotdl:spotdl /app
+# Put the venv on PATH so `spotdl` runs directly (no `uv run` needed)
+ENV PATH="/app/.venv/bin:$PATH"
 
-# Pre-create the output directory so named volumes inherit writable ownership.
-RUN mkdir -p /music && chown spotdl:spotdl /music
+# Pre-create the music output dir AND the spotdl config dir, owned by spotdl.
+# Pre-creating ~/.config/spotdl is important: it lets users bind-mount a single
+# config.json file into it without Docker creating the parent dir as root
+# (which would block spotdl from writing temp/, errors/, .spotipy at runtime).
+RUN mkdir -p /music /home/spotdl/.config/spotdl \
+    && chown -R spotdl:spotdl /app /music /home/spotdl
 
 # Create a volume for the output directory
 VOLUME /music
@@ -50,5 +61,5 @@ WORKDIR /music
 # Switch to not root user
 USER spotdl
 
-# Entrypoint command
-ENTRYPOINT ["uv", "run", "--project", "/app", "--no-dev", "--frozen", "--no-sync", "spotdl"]
+# Entrypoint to run spotdl
+ENTRYPOINT ["spotdl"]

--- a/spotdl/console/web.py
+++ b/spotdl/console/web.py
@@ -10,8 +10,11 @@ import sys
 import webbrowser
 from pathlib import Path
 
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import Response
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import ClientDisconnect
 from uvicorn import Config, Server
 
 from spotdl._version import __version__
@@ -70,6 +73,15 @@ def web(web_settings: WebOptions, downloader_settings: DownloaderOptions):
         version=__version__,
         dependencies=[Depends(get_current_state)],
     )
+
+    class SuppressClientDisconnect(BaseHTTPMiddleware):
+        async def dispatch(self, request: Request, call_next):
+            try:
+                return await call_next(request)
+            except ClientDisconnect:
+                return Response(status_code=204)
+
+    app_state.api.add_middleware(SuppressClientDisconnect)
 
     app_state.api.include_router(api.router)
     app_state.api.include_router(routes.router)
@@ -141,7 +153,14 @@ def web(web_settings: WebOptions, downloader_settings: DownloaderOptions):
         frame (FrameType): The current stack frame.
 
         """
+        # Cancel all pending disconnect timers so non-daemon threads don't
+        # block the process from exiting.
+        for client in list(app_state.clients.values()):
+            if client.disconnect_timer and client.disconnect_timer.is_alive():
+                client.disconnect_timer.cancel()
+
         app_state.server.should_exit = True
+        app_state.server.force_exit = True
 
     signal.signal(signal.SIGINT, handle_shutdown)
     signal.signal(signal.SIGTERM, handle_shutdown)

--- a/spotdl/console/web.py
+++ b/spotdl/console/web.py
@@ -75,7 +75,12 @@ def web(web_settings: WebOptions, downloader_settings: DownloaderOptions):
     )
 
     class SuppressClientDisconnect(BaseHTTPMiddleware):
+        """Return 204 when the client closes the connection mid-request."""
+
         async def dispatch(self, request: Request, call_next):
+            """
+            Run the request handler and swallow ClientDisconnect exceptions.
+            """
             try:
                 return await call_next(request)
             except ClientDisconnect:

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -26,7 +26,6 @@ from spotdl.providers.audio import (
     YouTube,
     YouTubeMusic,
 )
-from spotdl.providers.audio.base import AudioProviderError
 from spotdl.providers.lyrics import AzLyrics, Genius, LyricsProvider, MusixMatch, Synced
 from spotdl.types.options import DownloaderOptionalOptions, DownloaderOptions
 from spotdl.types.song import Song
@@ -677,9 +676,7 @@ class Downloader:
 
             if song.download_url is not None:
                 download_url = song.download_url
-                logger.debug(
-                    "Downloading %s using %s", song.display_name, download_url
-                )
+                logger.debug("Downloading %s using %s", song.display_name, download_url)
                 download_info = audio_downloader.get_download_metadata(
                     download_url, download=True
                 )
@@ -690,7 +687,6 @@ class Downloader:
             else:
                 download_info = None
                 download_url = None
-                last_provider_error: Optional[Exception] = None
                 provider_results: List[str] = []
                 failed_urls: set = set()
                 providers = self.audio_providers
@@ -718,7 +714,10 @@ class Downloader:
                             )
                             continue
                         if provider_url in failed_urls:
-                            result_msg = f"{audio_provider.name}: skipped (same URL already failed: {provider_url})"
+                            result_msg = (
+                                f"{audio_provider.name}: skipped "
+                                f"(same URL already failed: {provider_url})"
+                            )
                             provider_results.append(result_msg)
                             logger.debug(
                                 "[%d/%d] %s",
@@ -765,15 +764,23 @@ class Downloader:
                             len(providers),
                             result_msg,
                         )
-                        last_provider_error = exc
                         if provider_url:
                             failed_urls.add(provider_url)
 
                 if download_info is None:
-                    summary = " | ".join(provider_results) if provider_results else "no providers available"
+                    summary = (
+                        " | ".join(provider_results)
+                        if provider_results
+                        else "no providers available"
+                    )
                     raise DownloaderError(
                         f"All providers failed for: {song.name} - {song.artist} [{summary}]"
                     )
+
+            if download_info is None:
+                raise DownloaderError(
+                    f"Failed to download: {song.name} - {song.artist}"
+                )
 
             temp_file = Path(
                 temp_folder / f"{download_info['id']}.{download_info['ext']}"

--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -26,6 +26,7 @@ from spotdl.providers.audio import (
     YouTube,
     YouTubeMusic,
 )
+from spotdl.providers.audio.base import AudioProviderError
 from spotdl.providers.lyrics import AzLyrics, Genius, LyricsProvider, MusixMatch, Synced
 from spotdl.types.options import DownloaderOptionalOptions, DownloaderOptions
 from spotdl.types.song import Song
@@ -674,26 +675,105 @@ class Downloader:
                 display_progress_tracker.yt_dlp_progress_hook
             )
 
-            if song.download_url is None:
-                download_url = self.search(song)
-            else:
+            if song.download_url is not None:
                 download_url = song.download_url
-
-            logger.debug("Downloading %s using %s", song.display_name, download_url)
-            download_info = audio_downloader.get_download_metadata(
-                download_url, download=True
-            )
-
-            if download_info is None:
                 logger.debug(
-                    "No download info found for %s, url: %s",
-                    song.display_name,
-                    download_url,
+                    "Downloading %s using %s", song.display_name, download_url
                 )
+                download_info = audio_downloader.get_download_metadata(
+                    download_url, download=True
+                )
+                if download_info is None:
+                    raise DownloaderError(
+                        f"yt-dlp failed to get metadata for: {song.name} - {song.artist}"
+                    )
+            else:
+                download_info = None
+                download_url = None
+                last_provider_error: Optional[Exception] = None
+                provider_results: List[str] = []
+                failed_urls: set = set()
+                providers = self.audio_providers
+                for idx, audio_provider in enumerate(providers, 1):
+                    provider_url = None
+                    logger.debug(
+                        "[%d/%d] Trying provider %s for %s",
+                        idx,
+                        len(providers),
+                        audio_provider.name,
+                        song.display_name,
+                    )
+                    try:
+                        provider_url = audio_provider.search(
+                            song, self.settings["only_verified_results"]
+                        )
+                        if not provider_url:
+                            result_msg = f"{audio_provider.name}: no results"
+                            provider_results.append(result_msg)
+                            logger.debug(
+                                "[%d/%d] %s",
+                                idx,
+                                len(providers),
+                                result_msg,
+                            )
+                            continue
+                        if provider_url in failed_urls:
+                            result_msg = f"{audio_provider.name}: skipped (same URL already failed: {provider_url})"
+                            provider_results.append(result_msg)
+                            logger.debug(
+                                "[%d/%d] %s",
+                                idx,
+                                len(providers),
+                                result_msg,
+                            )
+                            continue
+                        logger.debug(
+                            "[%d/%d] %s found URL %s — attempting download",
+                            idx,
+                            len(providers),
+                            audio_provider.name,
+                            provider_url,
+                        )
+                        provider_download_info = audio_downloader.get_download_metadata(
+                            provider_url, download=True
+                        )
+                        if provider_download_info is not None:
+                            download_url = provider_url
+                            download_info = provider_download_info
+                            logger.debug(
+                                "[%d/%d] %s succeeded for %s",
+                                idx,
+                                len(providers),
+                                audio_provider.name,
+                                song.display_name,
+                            )
+                            break
+                        result_msg = f"{audio_provider.name}: no download info"
+                        provider_results.append(result_msg)
+                        logger.debug(
+                            "[%d/%d] %s",
+                            idx,
+                            len(providers),
+                            result_msg,
+                        )
+                    except Exception as exc:
+                        result_msg = f"{audio_provider.name}: {exc}"
+                        provider_results.append(result_msg)
+                        logger.debug(
+                            "[%d/%d] %s",
+                            idx,
+                            len(providers),
+                            result_msg,
+                        )
+                        last_provider_error = exc
+                        if provider_url:
+                            failed_urls.add(provider_url)
 
-                raise DownloaderError(
-                    f"yt-dlp failed to get metadata for: {song.name} - {song.artist}"
-                )
+                if download_info is None:
+                    summary = " | ".join(provider_results) if provider_results else "no providers available"
+                    raise DownloaderError(
+                        f"All providers failed for: {song.name} - {song.artist} [{summary}]"
+                    )
 
             temp_file = Path(
                 temp_folder / f"{download_info['id']}.{download_info['ext']}"

--- a/spotdl/utils/web.py
+++ b/spotdl/utils/web.py
@@ -117,6 +117,7 @@ class Client:
         )
 
         self.disconnect_timer = None
+        self.active_download_urls: set = set()
 
     async def connect(self):
         """
@@ -146,6 +147,7 @@ class Client:
             "Client %s will disconnect in 15 seconds of inactivity", self.client_id
         )
         self.disconnect_timer = threading.Timer(15, self.disconnect_now)
+        self.disconnect_timer.daemon = True
         self.disconnect_timer.start()
 
     def disconnect_now(self):

--- a/spotdl/web/routes.py
+++ b/spotdl/web/routes.py
@@ -8,11 +8,15 @@ from pathlib import Path
 from typing import Any, Optional, cast
 
 # from datastar_py.sse import DatastarEvent
-from datastar_py.fastapi import ReadSignals
+from datastar_py.fastapi import (
+    ReadSignals,
+)
 from datastar_py.fastapi import (
     ServerSentEventGenerator as SSE,  # DatastarResponse,; read_signals,
 )
-from datastar_py.fastapi import datastar_response
+from datastar_py.fastapi import (
+    datastar_response,
+)
 from fastapi import APIRouter, Request
 from fastapi.templating import Jinja2Templates
 
@@ -405,7 +409,9 @@ async def gen_download(signals: Signals):
         app_state.logger.info(f"[{signals.client_id}] Fetching metadata...")
         songs = await asyncio.to_thread(get_simple_songs, [url])
 
-        app_state.logger.info(f"[{signals.client_id}] Resolved {len(songs)} song(s), starting download from: {url}")
+        app_state.logger.info(
+            f"[{signals.client_id}] Resolved {len(songs)} song(s), starting download from: {url}"
+        )
 
         # Download all songs concurrently. pool_download() acquires the
         # downloader's semaphore (sized to the "threads" setting, e.g. 4), so

--- a/spotdl/web/routes.py
+++ b/spotdl/web/routes.py
@@ -4,6 +4,7 @@ Module which contains the web client routes and functions.
 
 import asyncio
 import uuid
+from pathlib import Path
 from typing import Any, Optional, cast
 
 # from datastar_py.sse import DatastarEvent
@@ -17,10 +18,9 @@ from fastapi.templating import Jinja2Templates
 
 from spotdl._version import __version__
 from spotdl.download.downloader import AUDIO_PROVIDERS, LYRICS_PROVIDERS
-from spotdl.types.song import Song
 from spotdl.utils.config import get_spotdl_path
 from spotdl.utils.ffmpeg import FFMPEG_FORMATS
-from spotdl.utils.search import get_search_results
+from spotdl.utils.search import get_search_results, get_simple_songs
 from spotdl.utils.web import Client, app_state, validate_search_term
 from spotdl.web.utils import Signals, handle_signals
 
@@ -28,7 +28,26 @@ __all__ = ["router"]
 
 router = APIRouter()
 
-templates = Jinja2Templates(directory="spotdl/web/components")
+# Resolve the templates directory relative to this package so the web UI works
+# regardless of the current working directory (e.g. inside Docker, WORKDIR=/music).
+templates = Jinja2Templates(directory=str(Path(__file__).parent / "components"))
+
+# Strong references to background download tasks.
+# asyncio only keeps a *weak* reference to tasks created with create_task(),
+# so without this the task can be garbage-collected the moment it suspends on
+# its first `await` (e.g. await asyncio.to_thread(Playlist.from_url, ...)),
+# causing the download to silently vanish.
+_background_tasks: set = set()
+
+
+def _spawn_background_task(coro) -> None:
+    """
+    Schedule a coroutine as a background task and retain a strong reference to
+    it until it completes, so it is not garbage-collected mid-execution.
+    """
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
 
 
 # PATHS
@@ -126,18 +145,31 @@ async def handle_get_client_search(datastar_signals: ReadSignals):
     """
     app_state.logger.info("Loading search...")
     signals = handle_signals(datastar_signals)
+
+    # If the client ID is stale (server restarted), create a new one and inform the browser.
+    if signals.client_id and Client.get_instance(signals.client_id) is None:
+        app_state.logger.warning(
+            f"Client {signals.client_id} not found in search, creating new client..."
+        )
+        signals.client_id = uuid.uuid4().hex
+        client = Client(signals.client_id)
+        await client.connect()
+        yield SSE.patch_signals({"client_id": signals.client_id})
+
     app_state.logger.info(f"[{signals.client_id}] Search term: {signals.search_term}")
     is_valid_url = validate_search_term(signals.search_term)
 
     if is_valid_url:
-        # redirect client to downloads page
         app_state.logger.info(
             f"[{signals.client_id}] Valid URL detected, redirecting to downloads..."
         )
-        yield SSE.redirect("/downloads")
         signals.song_url = signals.search_term
-        async for update in gen_download(signals):
-            yield update
+        # Start the download as a background task BEFORE redirecting.
+        # If we redirect first, the browser closes this SSE connection and the
+        # generator gets cancelled before gen_download can run.
+        _spawn_background_task(_run_download_task(signals))
+        yield SSE.redirect("/downloads")
+        return
 
     songs = get_search_results(signals.search_term)
     yield SSE.patch_elements(
@@ -289,6 +321,43 @@ async def handle_post_client_download(datastar_signals: ReadSignals):
 # HELPERS
 
 
+async def _run_download_task(signals: Signals):
+    """
+    Background task wrapper for gen_download.
+    Consumes the generator without yielding to any SSE stream,
+    so it survives the closure of the search SSE connection.
+    Deduplicates by URL so datastar retries don't trigger multiple downloads.
+    """
+    app_state.logger.info(
+        f"[{signals.client_id}] Background download task started for: {signals.song_url}"
+    )
+    client = Client.get_instance(signals.client_id)
+    if client is None:
+        app_state.logger.warning(
+            f"[{signals.client_id}] Client not found in background task, aborting."
+        )
+        return
+    url = signals.song_url
+    if url in client.active_download_urls:
+        app_state.logger.info(
+            f"[{signals.client_id}] Download already in progress for {url}, skipping duplicate."
+        )
+        return
+    client.active_download_urls.add(url)
+    try:
+        async for _ in gen_download(signals):
+            pass
+    except BaseException as exc:
+        app_state.logger.error(
+            f"[{signals.client_id}] Background download task failed ({type(exc).__name__}): {exc}"
+        )
+    finally:
+        client.active_download_urls.discard(url)
+        app_state.logger.info(
+            f"[{signals.client_id}] Background download task finished for: {url}"
+        )
+
+
 async def gen_download(signals: Signals):
     """
     Generate the download process for the client.
@@ -318,22 +387,50 @@ async def gen_download(signals: Signals):
         )
 
     try:
-        # Fetch song metadata
-        song = Song.from_url(signals.song_url)
-        app_state.logger.info(f"Downloading song: {song}")
+        url = signals.song_url
+        app_state.logger.info(f"[{signals.client_id}] Resolving URL: {url}")
 
-        # Download Song
-        _, path = await client.downloader.pool_download(song)
+        # Resolve the URL (track / playlist / album / artist) into a flat list of
+        # Song objects using the same canonical resolver the CLI uses.
+        # get_simple_songs():
+        #   * already calls *.from_url(url, fetch_songs=False), so it does NOT
+        #     make one slow Spotify call per song (doing so made playlists appear
+        #     to hang), and
+        #   * populates each song's list_name/list_url/list_position/list_length,
+        #     which the output template "{list-name}/..." relies on. Without it the
+        #     template collapses to "/..." (an absolute path to the filesystem
+        #     root) and ffmpeg fails with "Permission denied".
+        # It internally calls asyncio.run() via spotipyfree, so it must run in a
+        # worker thread to avoid clashing with the server's running event loop.
+        app_state.logger.info(f"[{signals.client_id}] Fetching metadata...")
+        songs = await asyncio.to_thread(get_simple_songs, [url])
+
+        app_state.logger.info(f"[{signals.client_id}] Resolved {len(songs)} song(s), starting download from: {url}")
+
+        # Download all songs concurrently. pool_download() acquires the
+        # downloader's semaphore (sized to the "threads" setting, e.g. 4), so
+        # gathering every task at once still only runs N downloads in parallel
+        # instead of one-at-a-time.
+        client.downloader.progress_handler.set_song_count(len(songs))
+        results = await asyncio.gather(
+            *(client.downloader.pool_download(song) for song in songs),
+            return_exceptions=True,
+        )
+        for song, result in zip(songs, results):
+            if isinstance(result, BaseException):
+                app_state.logger.error(
+                    f"[{signals.client_id}] Error downloading {song.name}: {result}"
+                )
+                continue
+            _, path = result
+            if path is None:
+                app_state.logger.error(f"Failure downloading {song.name}")
+
         yield SSE.patch_elements(f"""
             <button id="download-{signals.song_url}" class="btn btn-primary btn-square">
                     <iconify-icon icon="clarity:check-line" style="font-size: 24px"></iconify-icon>
                 </button>
         """)
-
-        if path is None:
-            app_state.logger.error(f"Failure downloading {song.name}")
-
-        # return str(path.absolute())
 
     except Exception as exception:
         app_state.logger.error(f"Error downloading! {exception}")

--- a/uv.lock
+++ b/uv.lock
@@ -727,11 +727,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.14"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/b1/efac073e0c297ecf2fb33c346989a529d4e19164f1759102dee5953ee17e/idna-3.14.tar.gz", hash = "sha256:466d810d7a2cc1022bea9b037c39728d51ae7dad40d480fc9b7d7ecf98ba8ee3", size = 198272, upload-time = "2026-05-10T20:32:15.935Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/3c/3f62dee257eb3d6b2c1ef2a09d36d9793c7111156a73b5654d2c2305e5ce/idna-3.14-py3-none-any.whl", hash = "sha256:e677eaf072e290f7b725f9acf0b3a2bd55f9fd6f7c70abe5f0e34823d0accf69", size = 72184, upload-time = "2026-05-10T20:32:14.295Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
This PR fixes several bugs in the web UI when running spotDL inside Docker, and improves the Docker image build.

Web UI:
* Downloads no longer vanish when a valid Spotify URL is submitted: the download runs in a retained background task started before redirecting to /downloads, so closing the search SSE connection does not cancel it.
* Playlist, album, and artist URLs are now fully resolved via get_simple_songs (same resolver as the CLI) and downloaded concurrently with asyncio.gather, bounded by the downloader thread semaphore.
* Jinja2 templates are resolved relative to the package (Path(__file__).parent / "components") instead of the CWD, so the web UI works when WORKDIR is not the project root (e.g. Docker with WORKDIR=/music).
* List metadata (list_name, list_position, etc.) is populated, so output templates like {list-name}/{list-position} - {title}.{output-ext} resolve correctly instead of writing to the filesystem root.
* Stale client_id values after a server restart are recovered by creating a new client and pushing the new ID back to the browser.
* Duplicate download requests for the same URL are skipped via per-client active_download_urls tracking.
* Clean shutdown: disconnect timers are cancelled on SIGINT/SIGTERM, timers run as daemon threads, and ClientDisconnect returns 204 instead of surfacing as an error.

Docker:
* Rebuilt on python:3.13-slim-bookworm (was Alpine) with uv and deno from official images.
* Copy only build-required files; install into /app/.venv on PATH; purge build toolchain in the same layer.
* Pre-create ~/.config/spotdl so a single config.json can be bind-mounted without Docker creating a root-owned parent directory.


Downloader:
* When a song has no pre-resolved download_url, iterate configured audio providers in order until one succeeds. Per-provider outcomes are logged; URLs that already failed are skipped.

## Related Issue
Fixes #2680

(For the Docker and downloader changes there is no dedicated open issue yet. Happy to open separate issues and split this PR if maintainers prefer.)

## Motivation and Context
Running spotdl web inside Docker exposed multiple failures:
* Playlist URLs did nothing useful — reported in #2680: redirect happened but downloads never started, or only a single track was attempted via Song.from_url.
* Background task GC — asyncio.create_task() without a strong reference caused downloads to disappear on the first await.
* Broken output paths — empty {list-name} with WORKDIR=/music produced absolute paths like /..., causing ffmpeg Permission denied.
* Docker friction — Alpine build was fragile; Deno was missing (needed by yt-dlp for some YouTube downloads); bind-mounting config.json failed when the parent directory was created as root.

The multi-provider fallback addresses cases where the primary provider finds a URL but yt-dlp fails to download it. Unlike the reverted search_all() path (#2672), each attempt uses the normal search() flow for that provider, and the Docker image now ships Deno.

## How Has This Been Tested?
Environment: Linux, Python 3.12/3.13, Docker with WORKDIR=/music, bind-mounted config.json and /music output volume.

Manual tests:
- [x] docker build -t spotdl . — image builds successfully
- [x] docker run … spotdl web — web UI loads at http://localhost:8800
- [x] Single track URL — download completes on /downloads
- [x] Playlist URL (https://open.spotify.com/playlist/xxxxxxxxxxxx) — all tracks download into {list-name}/ under /music
- [x] Server restart + new search — stale client_id recovered without error
- [x] Ctrl+C shutdown — process exits cleanly, no hung threads
- [x] CLI still works: spotdl download <track-url>

Lint / type-check (on changed files):
```
black spotdl/console/web.py spotdl/download/downloader.py spotdl/utils/web.py spotdl/web/routes.py
isort spotdl/console/web.py spotdl/download/downloader.py spotdl/utils/web.py spotdl/web/routes.py
pylint --fail-under 10 --limit-inference-results 0 --disable=R0917 spotdl/console/web.py spotdl/download/downloader.py spotdl/utils/web.py spotdl/web/routes.py
mypy --ignore-missing-imports spotdl/console/web.py spotdl/download/downloader.py spotdl/utils/web.py spotdl/web/routes.py
```
All passed.

## Screenshots (if appropriate)
N/A — behaviour verified via logs and downloaded files in /music.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
