### PR TITLE
Fix SoundCloud result duration reported in milliseconds

### DIFF
--- a/spotdl/providers/audio/soundcloud.py
+++ b/spotdl/providers/audio/soundcloud.py
@@ -83,7 +83,7 @@ class SoundCloud(AudioProvider):
                     verified=result.user.verified,
                     # SoundCloud reports duration in milliseconds, but the
                     # matcher (and every other provider) works in seconds.
-                    duration=round(result.full_duration / 1000),
+                    duration=result.full_duration / 1000,
                     author=result.user.username,
                     result_id=str(result.id),
                     isrc_search=False,

--- a/spotdl/providers/audio/soundcloud.py
+++ b/spotdl/providers/audio/soundcloud.py
@@ -81,7 +81,9 @@ class SoundCloud(AudioProvider):
                     url=result.permalink_url,
                     name=result.title,
                     verified=result.user.verified,
-                    duration=result.full_duration,
+                    # SoundCloud reports duration in milliseconds, but the
+                    # matcher (and every other provider) works in seconds.
+                    duration=round(result.full_duration / 1000),
                     author=result.user.username,
                     result_id=str(result.id),
                     isrc_search=False,


### PR DESCRIPTION
## Description
SoundCloud's API returns a track's `full_duration` in **milliseconds**, but the matcher's `calc_time_match` (and every other audio provider) works in **seconds**. Because the SoundCloud provider passed `full_duration` straight through, every SoundCloud result had a duration ~1000x too large.

`calc_time_match` therefore computed an enormous time difference for every SoundCloud result, `exp(-0.1 * time_diff)` collapsed the score to ~0, and results were dropped by the `time_match < 25` gate in `order_results` before name/artist scoring ever mattered.

This PR converts `full_duration` from milliseconds to seconds so SoundCloud results are scored on the same basis as other providers.

## Related Issue
Contributes to https://github.com/spotDL/spotify-downloader/issues/2704 (SoundCloud matching not working). Note this is only one of the two problems behind that issue: the other is that the SoundCloud provider does not populate `artists`, addressed separately in #2707.

## Motivation and Context
Without this fix, valid SoundCloud matches are silently discarded on the duration gate, so `downloader.search()` can raise `LookupError: No results found` even for an exact match.

## How Has This Been Tested?
Verified locally against the track in #2704 (`https://open.spotify.com/track/7yfMsNxODzSIysdZ47JrlG`).

- With the current code, `order_results` returns 0 scored SoundCloud results and `downloader.search()` raises `No results found`.
- With this duration fix (plus `artists` populated as in #2707), the expected result `https://soundcloud.com/tokiwa_anka/pnog8medav1f` scores 100.0 and `time_match` goes from 0.0 to 100.0.

Ran `black --check` and `pylint --fail-under 10` on the changed file, both pass.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)