### PR TITLE
Fix operator precedence bug in convert() stream-copy condition

### DIFF
--- a/spotdl/utils/ffmpeg.py
+++ b/spotdl/utils/ffmpeg.py
@@ -289,8 +289,7 @@ def _build_ffmpeg_arguments(
         if (
             (output_format == "opus" and file_format == "webm")
             or (output_format == "m4a" and file_format == "m4a")
-            and not (bitrate or ffmpeg_args)
-        ):
+        ) and not (bitrate or ffmpeg_args):
             arguments.extend(["-vn", "-c:a", "copy"])
         else:
             arguments.extend(FFMPEG_FORMATS[output_format])


### PR DESCRIPTION
## Description
Fixes an operator-precedence bug in `convert()` in `spotdl/utils/ffmpeg.py`. The stream-copy condition:

```python
if (
    (output_format == "opus" and file_format == "webm")
    or (output_format == "m4a" and file_format == "m4a")
    and not (bitrate or ffmpeg_args)
):
```

parses as `A or (B and C)` because `and` binds tighter than `or`, so the `not (bitrate or ffmpeg_args)` guard was only applied to the m4a arm. For opus output from a webm source, ffmpeg always used `-vn -c:a copy` and silently ignored user-supplied `--bitrate` / `--ffmpeg-args`.

This PR parenthesizes the `or` so the guard applies to both arms:

```python
if (
    (output_format == "opus" and file_format == "webm")
    or (output_format == "m4a" and file_format == "m4a")
) and not (bitrate or ffmpeg_args):
```

This restores the semantics of the original condition (`output_format in ["m4a", "opus"] and not (bitrate or ffmpeg_args)`) that was inadvertently changed in 6306a5a5 when the check was split per-format.

Note: #2722 copies the buggy condition verbatim into the new `async_convert` — if that PR lands, the same one-line fix should be applied there (or the argument-building deduplicated).

## Related Issue
Fixes #2742

## Motivation and Context
`--bitrate` and `--ffmpeg-args` should always be honored. With opus output (the default YouTube audio stream is webm/opus), these options were silently dropped because the stream was copied instead of re-encoded.

## How Has This Been Tested?
Verified the parsed condition manually: with `output_format="opus"`, `file_format="webm"`, `bitrate="96k"`, the old condition selected `-c:a copy` (dropping the bitrate); the fixed condition selects `FFMPEG_FORMATS["opus"]` so `-b:a 96k` takes effect. Behaviour without bitrate/ffmpeg-args is unchanged (still stream-copies).

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed