### PR TITLE
Fix KeyError: 'videoDetails' when downloading from YouTube Music links

### DIFF
--- a/spotdl/utils/search.py
+++ b/spotdl/utils/search.py
@@ -190,7 +190,7 @@ def get_simple_songs(
                 yt_song.name = video_details["title"]
                 yt_song.artist = video_details["author"]
                 yt_song.artists = [video_details["author"]]
-                yt_song.duration = video_details["lengthSeconds"]
+                yt_song.duration = int(video_details["lengthSeconds"])
 
             yt_song.download_url = request
             songs.append(yt_song)

--- a/spotdl/utils/search.py
+++ b/spotdl/utils/search.py
@@ -174,15 +174,23 @@ def get_simple_songs(
         elif "music.youtube.com/watch?v" in request:
             track_data = get_ytm_client().get_song(request.split("?v=", 1)[1])
 
+            video_details = track_data.get("videoDetails")
+            if video_details is None:
+                logger.error(
+                    "Could not get metadata for YouTube Music link, skipping: %s",
+                    request,
+                )
+                continue
+
             yt_song = Song.from_search_term(
-                f"{track_data['videoDetails']['author']} - {track_data['videoDetails']['title']}"
+                f"{video_details['author']} - {video_details['title']}"
             )
 
             if use_ytm_data:
-                yt_song.name = track_data["title"]
-                yt_song.artist = track_data["author"]
-                yt_song.artists = [track_data["author"]]
-                yt_song.duration = track_data["lengthSeconds"]
+                yt_song.name = video_details["title"]
+                yt_song.artist = video_details["author"]
+                yt_song.artists = [video_details["author"]]
+                yt_song.duration = video_details["lengthSeconds"]
 
             yt_song.download_url = request
             songs.append(yt_song)

--- a/tests/utils/test_search.py
+++ b/tests/utils/test_search.py
@@ -89,3 +89,15 @@ def test_create_empty_song():
 def test_get_simple_songs():
     songs = get_simple_songs(QUERY)
     assert len(songs) > 1
+
+
+def test_get_simple_songs_skips_missing_video_details(monkeypatch):
+    class FakeYTMClient:
+        def get_song(self, video_id):
+            return {"playabilityStatus": {"status": "ERROR"}}
+
+    monkeypatch.setattr("spotdl.utils.search.get_ytm_client", lambda: FakeYTMClient())
+
+    songs = get_simple_songs(["https://music.youtube.com/watch?v=dQw4w9WgXcQ"])
+
+    assert songs == []


### PR DESCRIPTION
## Description
When `ytmusicapi`'s `get_song()` returns a response without `videoDetails` (e.g. the video is unavailable, private, or region-blocked), spotdl crashed with `KeyError: 'videoDetails'` while parsing the query. This now logs an error with the offending URL and skips the song, so large batch/sync runs continue instead of aborting — consistent with how per-song fetch failures are already handled in `parse_query`.

This also fixes a latent bug in the `--use-ytm-data` branch: it read top-level `track_data["title"]` / `["author"]` / `["lengthSeconds"]`, but `get_song()` returns the raw player response, which only has those keys inside `videoDetails` — so that path raised `KeyError` even when `videoDetails` was present.

## Related Issue
Closes #2375
Supersedes #2376 (answers the open review question there: we log an error and skip rather than raise, since raising would abort an entire batch sync at query-parse time)

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the code style of this project (black/mypy/pylint clean)
- [x] All new and existing tests passed

Co-authored-by: blastbeng <rodfval.fv@gmail.com>