### PR TITLE
Upgrade spotapi to 1.2.8, drop tls_client bundling from build script

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,10 +1,7 @@
-import ctypes
 import os
 import sys
 from importlib.metadata import metadata
-from importlib.util import find_spec
 from pathlib import Path
-from platform import machine
 
 import PyInstaller.__main__  # type: ignore
 import pykakasi
@@ -24,35 +21,14 @@ WEB_COMPONENTS_PATH = str(Path(spotdl.__file__).parent / "web" / "components")
 modules = set(
     module.split(" ")[0] for module in metadata("spotdl").get_all("Requires-Dist", [])
 )
+# spotapi is a transitive dependency (via spotipyFree), so it is not in
+# Requires-Dist; curl_cffi is spotapi's HTTP backend and ships a compiled
+# extension with no pyinstaller-hooks-contrib hook, so collect it explicitly
 modules.update(
     {
         "spotapi",
+        "curl_cffi",
     }
-)
-
-tls_client_spec = find_spec("tls_client")
-if tls_client_spec is None or tls_client_spec.origin is None:
-    raise RuntimeError("Could not find tls_client package")
-
-tls_client_path = Path(tls_client_spec.origin).parent
-# This branch logic is copied verbatim from tls_client/cffi.py and must stay
-# in sync with it, so that the bundled binary is exactly the one the runtime
-# loader will request. Note "x86" in machine() matches x86_64 on Linux — that
-# is not a bug here; tls_client's own loader picks tls-client-x86.so there too.
-if sys.platform == "darwin":
-    tls_client_file_ext = "-arm64.dylib" if machine() == "arm64" else "-x86.dylib"
-elif sys.platform in ("win32", "cygwin"):
-    tls_client_file_ext = "-64.dll" if ctypes.sizeof(ctypes.c_voidp) == 8 else "-32.dll"
-else:
-    if machine() == "aarch64":
-        tls_client_file_ext = "-arm64.so"
-    elif "x86" in machine():
-        tls_client_file_ext = "-x86.so"
-    else:
-        tls_client_file_ext = "-amd64.so"
-
-TLS_CLIENT_BINARY = str(
-    tls_client_path / "dependencies" / f"tls-client{tls_client_file_ext}"
 )
 
 PyInstaller.__main__.run(
@@ -67,8 +43,6 @@ PyInstaller.__main__.run(
         f"{WEB_STATIC_PATH}{os.pathsep}spotdl/web/static",
         "--add-data",
         f"{WEB_COMPONENTS_PATH}{os.pathsep}spotdl/web/components",
-        "--add-binary",
-        f"{TLS_CLIENT_BINARY}{os.pathsep}tls_client/dependencies",
         f"--additional-hooks-dir={YTDLP_PATH}",
         "--name",
         f"spotdl-{__version__}-{sys.platform}",

--- a/uv.lock
+++ b/uv.lock
@@ -2541,22 +2541,22 @@ wheels = [
 
 [[package]]
 name = "spotapi"
-version = "1.2.7"
+version = "1.2.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4", marker = "platform_python_implementation == 'CPython'" },
     { name = "colorama", marker = "platform_python_implementation == 'CPython'" },
+    { name = "curl-cffi", marker = "platform_python_implementation == 'CPython'" },
     { name = "pillow", marker = "platform_python_implementation == 'CPython'" },
     { name = "pyotp", marker = "platform_python_implementation == 'CPython'" },
     { name = "readerwriterlock", marker = "platform_python_implementation == 'CPython'" },
     { name = "requests", marker = "platform_python_implementation == 'CPython'" },
-    { name = "tls-client", marker = "platform_python_implementation == 'CPython'" },
     { name = "typing-extensions", marker = "platform_python_implementation == 'CPython'" },
     { name = "validators", marker = "platform_python_implementation == 'CPython'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/cb/7fddf710e4eaba6b27dfba8b951dca2fe160a6495139819e4b402f8a4c85/spotapi-1.2.7.tar.gz", hash = "sha256:c78500eb903852fc6a943379ba91ec3cf6b9caff20299c3792a2e8bbfd7156d6", size = 54755, upload-time = "2025-12-14T15:43:49.156Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/b6/fe67cb2df5545999ae006f7664de00f55af9ebff65783bf8abd727a0ff90/spotapi-1.2.8.tar.gz", hash = "sha256:8535c820522e05e6959742e9e636d52a3c151b37130460ff47a46cae283577a1", size = 58540, upload-time = "2026-06-14T09:24:41.99Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/e9/758080fa98dd27e872fa9811980f9b2f6563a3c4e55c2b70200314fef047/spotapi-1.2.7-py3-none-any.whl", hash = "sha256:9b8b11b1d4fd34473b2124ed1c03bc8ae55b86faba762d892031d3afd159a4f6", size = 66820, upload-time = "2025-12-14T15:43:47.994Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ff/0491c208050d5aaab26ede9df11e4e8ff2e1cc0cf0421c8e18deff37c974/spotapi-1.2.8-py3-none-any.whl", hash = "sha256:dc5716b215ef207b97249a70347965981c30102899dbe727b1b5f1e643ba179e", size = 70325, upload-time = "2026-06-14T09:24:40.991Z" },
 ]
 
 [[package]]
@@ -2746,15 +2746,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
-]
-
-[[package]]
-name = "tls-client"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3c/a6/6ec27c66a836a11a085e841f825d2f5bd289092f3bcd2f645558f587c89f/tls_client-1.0.1.tar.gz", hash = "sha256:dad797f3412bb713606e0765d489f547ffb580c5ffdb74aed47a183ce8505ff5", size = 16414, upload-time = "2024-02-02T18:55:55.767Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/cd/5c735818692927e07980357445569adb6ee204c3332d19c516bae01c6cfa/tls_client-1.0.1-py3-none-any.whl", hash = "sha256:2f8915c0642c2226c9e33120072a2af082812f6310d32f4ea4da322db7d3bb1c", size = 41287556, upload-time = "2024-02-02T18:55:52.226Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Upgrades spotapi 1.2.7 -> 1.2.8 (via `uv lock --upgrade-package spotapi`) and removes the tls_client platform-specific binary bundling from `scripts/build.py`, resolving the question raised in #2745 review.

- spotapi 1.2.8 replaced `tls_client` with `curl_cffi` ([Aran404/SpotAPI#78](https://github.com/Aran404/SpotAPI/pull/78)), so `tls-client` (a 41 MB wheel) drops out of the dependency tree entirely and the `--add-binary` workaround is no longer needed.
- `curl_cffi` was already in the tree via soundcloud-v2, so no new dependency is introduced. It is added to the `--collect-all` set explicitly because it ships a compiled extension and pyinstaller-hooks-contrib (2026.5) has no hook for it.
- 1.2.8 also brings token refresh on expiry/auth failure and updated fallback client secrets, both relevant to spotDL''s anonymous metadata access.

## Verification

- Full PyInstaller build on Windows; frozen exe starts, prints version, and serves the web UI.
- The entry point import chain (`spotdl.utils.spotify` -> `SpotipyFree` -> `spotapi` -> `curl_cffi`) loads in the frozen exe, confirming the compiled curl_cffi extension is bundled without any manual binary handling.
- `tls_client` is no longer imported anywhere.
