### PR TITLE
Fix startup crash from yt-dlp Python 3.10 deprecation notice

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,10 +21,10 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv venv --python 3.10
+          uv venv --python 3.13
           uv sync
 
       - name: Install twine
@@ -56,10 +56,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv venv --python 3.10
+          uv venv --python 3.13
           uv sync
 
       - name: Build executable

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv venv --python 3.10
+          uv venv --python 3.13
           uv sync
 
       - name: Build executable

--- a/spotdl/providers/audio/base.py
+++ b/spotdl/providers/audio/base.py
@@ -55,6 +55,12 @@ class YTDLLogger:
         YTDL uses this to print errors.
         """
 
+        # yt-dlp routes deprecation notices (e.g. old Python versions) through
+        # the error channel; they are not download failures
+        if "Deprecated Feature" in msg:
+            logger.debug(msg)
+            return
+
         raise AudioProviderError(msg)
 
 


### PR DESCRIPTION
## What

The v4.5.1 executables crash at startup with `AudioProviderError: Deprecated Feature: Support for Python version 3.10 has been deprecated` because:

1. yt-dlp 2026.07.04 emits a deprecation notice through its error-level logger channel when running on Python 3.10, and `YTDLLogger.error` raised it as an `AudioProviderError` during `YoutubeDL` construction.
2. CI builds the executables with Python 3.10.

## Fixes

- `YTDLLogger.error` now logs "Deprecated Feature" notices at debug level instead of raising; genuine yt-dlp errors still raise.
- Release workflows (`python-publish`, `release-build-check`) now build with Python 3.13.

## Verification

- Reproduced the crash on real Python 3.10 + yt-dlp 2026.7.4 and confirmed the fix intercepts it while `YoutubeDL` construction completes.
- Confirmed real error messages still raise `AudioProviderError`.

Note: pip users on Python 3.10 hit the same crash with spotdl 4.5.1, so the logger fix needs to ship in a patch release - the workflow bump alone only fixes the frozen builds.