### PR TITLE
Release v4.5.2

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,10 +21,10 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv venv --python 3.10
+          uv venv --python 3.13
           uv sync
 
       - name: Install twine
@@ -56,10 +56,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv venv --python 3.10
+          uv venv --python 3.13
           uv sync
 
       - name: Build executable

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv venv --python 3.10
+          uv venv --python 3.13
           uv sync
 
       - name: Build executable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spotdl"
-version = "4.5.1"
+version = "4.5.2"
 requires-python = ">=3.10,<3.15"
 
 description = "Download your Spotify playlists and songs along with album art and metadata"

--- a/spotdl/_version.py
+++ b/spotdl/_version.py
@@ -2,4 +2,4 @@
 Version module for spotdl.
 """
 
-__version__ = "4.5.1"
+__version__ = "4.5.2"

--- a/spotdl/providers/audio/base.py
+++ b/spotdl/providers/audio/base.py
@@ -55,6 +55,12 @@ class YTDLLogger:
         YTDL uses this to print errors.
         """
 
+        # yt-dlp routes deprecation notices (e.g. old Python versions) through
+        # the error channel; they are not download failures
+        if "Deprecated Feature" in msg:
+            logger.debug(msg)
+            return
+
         raise AudioProviderError(msg)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2561,7 +2561,7 @@ wheels = [
 
 [[package]]
 name = "spotdl"
-version = "4.5.1"
+version = "4.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4", marker = "platform_python_implementation == 'CPython'" },


### PR DESCRIPTION
## What

Patch release fixing the startup crash in v4.5.1.

- v4.5.1 crashes at startup on Python 3.10 (`AudioProviderError: Deprecated Feature: Support for Python version 3.10 has been deprecated`). This affects **all v4.5.1 executables** (CI built them with Python 3.10) and **pip installs running on Python 3.10** with yt-dlp >= 2026.07.04.
- The fix (#2748, already on master): `YTDLLogger` no longer raises on yt-dlp "Deprecated Feature" notices, and release workflows now build executables with Python 3.13.
- This PR bumps the version to 4.5.2 so the fix ships to PyPI and fresh executables are built through the corrected pipeline.

