### PR TITLE
Fix trailing single-backslash paths not detected in gen_m3u_files

### DIFF
--- a/spotdl/utils/m3u.py
+++ b/spotdl/utils/m3u.py
@@ -100,11 +100,7 @@ def gen_m3u_files(
 
     # If file_name ends with a slash. Does not have a m3u8 name with extension
     # at the end of the template, append `{list[0]}`` to it
-    if (
-        file_name.endswith("/")
-        or file_name.endswith(r"\\")
-        or file_name.endswith("\\\\")
-    ):
+    if file_name.endswith("/") or file_name.endswith("\\"):
         file_name += "/{list[0]}.m3u8"
 
     # Check if the file name ends with .m3u or .m3u8

--- a/tests/utils/test_m3u.py
+++ b/tests/utils/test_m3u.py
@@ -60,3 +60,21 @@ def _song(list_name):
         copyright_text=None,
         list_name=list_name,
     )
+
+
+def test_gen_m3u_files_trailing_backslash(monkeypatch):
+    """Regression test for #2727: a file_name ending in a single backslash
+    (plain Windows directory form, e.g. "C:\\Music\\") was not detected as
+    directory-only, so ".m3u8" was appended directly, producing a hidden
+    ".m3u8" file instead of "<list>.m3u8" inside the directory."""
+    captured = []
+    monkeypatch.setattr(
+        "spotdl.utils.m3u.create_m3u_file",
+        lambda file_name, *args: captured.append(file_name),
+    )
+    songs = [_song(list_name="mylist")]
+
+    gen_m3u_files(songs, "C:\\Music\\", "", "mp3")
+
+    assert captured, "create_m3u_file was never called"
+    assert captured[0].endswith("mylist.m3u8")


### PR DESCRIPTION
Fixes #2727

## What was wrong

`gen_m3u_files` tries to detect a directory-only `file_name` (one ending in a path separator) so it can append `{list[0]}.m3u8`. The forward-slash check works, but both backslash checks are two-backslash string literals — `r"\\"` and `"\\\\"` are the exact same two-character string — so a path ending in a single `\`, the normal Windows form, slips past the guard:

```python
>>> "C:\\Music\\".endswith(r"\\")   # single trailing backslash
False
```

The guard is skipped, `.m3u8` gets appended directly, and the user gets a hidden `C:\Music\.m3u8` file instead of `C:\Music\<list>.m3u8`.

## The fix

A single `endswith("\\")` (one backslash) covers both the single- and double-backslash forms, since it matches any trailing backslash. The redundant second branch is removed.

## Test

Added `test_gen_m3u_files_trailing_backslash`, which monkeypatches `create_m3u_file` to capture the file name it receives — testing the transformation itself, so it runs on any platform (no Windows-only skip). It fails on the old code and passes with the fix; the existing `test_gen_m3u_files` still passes.
