### PR TITLE
fix: strip /intl-xx/ prefix from urls (#2737)

### DIFF
--- a/spotdl/types/song.py
+++ b/spotdl/types/song.py
@@ -78,6 +78,7 @@ class Song:
         if "open.spotify.com" not in url or "track" not in url:
             raise SongError(f"Invalid URL: {url}")
         url = re.sub(r"\/intl-\w+\/", "/", url)
+
         # query spotify for song, artist, album details
         spotify_client = SpotifyClient()
 

--- a/spotdl/types/song.py
+++ b/spotdl/types/song.py
@@ -3,6 +3,7 @@ Song module that hold the Song and SongList classes.
 """
 
 import json
+import re
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -76,7 +77,7 @@ class Song:
 
         if "open.spotify.com" not in url or "track" not in url:
             raise SongError(f"Invalid URL: {url}")
-
+        url = re.sub(r"\/intl-\w+\/", "/", url)
         # query spotify for song, artist, album details
         spotify_client = SpotifyClient()
 

--- a/spotdl/utils/web.py
+++ b/spotdl/utils/web.py
@@ -6,6 +6,7 @@ FastAPI routes/classes etc.
 import asyncio
 import logging
 import mimetypes
+import re
 import threading
 from argparse import Namespace
 from typing import Any, Dict, Optional, Union
@@ -300,6 +301,8 @@ def validate_search_term(search_term: str) -> bool:
     ### Returns
     - True if the search term is valid, False otherwise.
     """
+    search_term = re.sub(r"\/intl-\w+\/", "/", search_term)
+
     return search_term != "" and (
         "://open.spotify.com/track/" in search_term
         or "://open.spotify.com/album/" in search_term

--- a/tests/types/test_song.py
+++ b/tests/types/test_song.py
@@ -83,9 +83,7 @@ def test_song_from_url():
     Tests if Song.from_url() works correctly.
     """
 
-    song = Song.from_url(
-        "https://open.spotify.com/intl-pt/track/1t2qKa8K72IBC8yQlhD9bU"
-    )
+    song = Song.from_url("https://open.spotify.com/track/1t2qKa8K72IBC8yQlhD9bU")
 
     assert song.name == "Ropes"
     assert song.artists == ["Dirty Palm", "Chandler Jewels"]
@@ -108,6 +106,21 @@ def test_song_from_url():
     assert song.explicit == False
     assert song.download_url == None
     assert song.popularity == 0
+
+
+@pytest.mark.vcr()
+@pytest.mark.default_cassette("test_song_from_url")
+def test_localized_song_url():
+    """
+    Tests if localized spotify urls work
+    """
+
+    song = Song.from_url(
+        "https://open.spotify.com/intl-pt/track/1t2qKa8K72IBC8yQlhD9bU"
+    )
+
+    assert song.name == "Ropes"
+    assert song.song_id == "1t2qKa8K72IBC8yQlhD9bU"
 
 
 # @pytest.mark.vcr()

--- a/tests/types/test_song.py
+++ b/tests/types/test_song.py
@@ -83,7 +83,9 @@ def test_song_from_url():
     Tests if Song.from_url() works correctly.
     """
 
-    song = Song.from_url("https://open.spotify.com/track/1t2qKa8K72IBC8yQlhD9bU")
+    song = Song.from_url(
+        "https://open.spotify.com/intl-pt/track/1t2qKa8K72IBC8yQlhD9bU"
+    )
 
     assert song.name == "Ropes"
     assert song.artists == ["Dirty Palm", "Chandler Jewels"]

--- a/tests/utils/test_web.py
+++ b/tests/utils/test_web.py
@@ -1,0 +1,7 @@
+from spotdl.utils.web import validate_search_term
+
+
+def test_web_searchterms():
+    url = "https://open.spotify.com/intl-pt/track/example"
+    result = validate_search_term(url)
+    assert result is True


### PR DESCRIPTION
   ## Description
  <!--- Describe your changes in detail -->
  Added /intl-xx/ url normalization to Song.from_url() and validate_search_term()
  Localized links should download properly now
  
  ## Related Issue
  Fixes #2737 
  
  ## Motivation and Context
  <!--- Why is this change required? What problem does it solve? -->
  
  Solves an issue where users copy a link from a localized web player (Separate language) spotdl does not recognize the url
  (e.g. Portuguese: https://open.spotify.com/intl-pt/track/........)
  
  ## How Has This Been Tested?
  <!--- Please describe in detail how you tested your changes. -->
  <!--- Include details of your testing environment, and the tests you ran to -->
  <!--- see how your change affects other areas of the code, etc. -->
  Python 3.11
  New web regression test passed
  black, isort, mypy, pylint pass

  ## Types of Changes
  <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  
  ## Checklist
  <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
  <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
  - [x] My code follows the code style of this project
  - [ ] My change requires a change to the documentation
  - [ ] I have updated the documentation accordingly
  - [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
  - [x] I have added tests to cover my changes
  - [ ] All new and existing tests passed
