### PR TITLE
fix: credit main artist match when result lists a single artist

### DIFF
--- a/spotdl/utils/matching.py
+++ b/spotdl/utils/matching.py
@@ -319,6 +319,13 @@ def calc_main_artist_match(song: Song, result: Result) -> float:
     # Result has only one artist, but song has multiple artists
     # we can assume that other artists are in the main artist name
     if len(song.artists) > 1 and len(result.artists) == 1:
+        # Credit the main artist first, otherwise an exact main artist match
+        # scores 0.0 whenever the other artists are not folded into the
+        # result's single artist name (they are often in the title instead)
+        main_artist_match = ratio(slug_song_main_artist, slug_result_main_artist) / len(
+            song.artists
+        )
+
         for artist in map(slugify, song.artists[1:]):
             artist = sort_string(slugify(artist).split("-"), "-")
 

--- a/tests/utils/test_matching.py
+++ b/tests/utils/test_matching.py
@@ -1,4 +1,16 @@
-from spotdl.utils.matching import calc_album_match
+from spotdl.utils.matching import calc_album_match, calc_main_artist_match
+
+
+def test_calc_main_artist_match_single_result_artist(mocker):
+    """
+    Test main artist matching when the song has multiple artists but the
+    result only lists the main one (the others are folded into the title).
+    """
+
+    song = mocker.Mock(song_id="song", artists=["LUCO", "Alice Gray"])
+    result = mocker.Mock(result_id="result", artists=["LUCO"])
+
+    assert calc_main_artist_match(song, result) > 0.0
 
 
 def test_calc_album_match_without_song_album(mocker):


### PR DESCRIPTION
## Description

`calc_main_artist_match` has a branch for songs with multiple artists whose result lists only one artist. That branch scored only the *secondary* artists against the result's single artist name and then returned early, so the main artists were never compared. The branch now starts from the main-artist ratio before adding the secondary-artist bonuses.

## Related Issue

Closes #2729

## Motivation and Context

YT Music usually credits only the main artist and folds features into the title (`Wasted (feat. Alice Gray)`). In that shape the secondary artist is not in the result's artist string, so the branch returned 0.0 even though `slugify(song.artists[0]) == slugify(result.artists[0])` — and `order_results` discarded the correct, verified, duration-exact result.

## How Has This Been Tested?

`calc_main_artist_match` for the issue's example goes from `0.0` to `50.0`. Added `test_calc_main_artist_match_single_result_artist`, which fails on master and passes with the fix; `tests/utils/test_matching.py`, `test_m3u.py` and `test_formatter.py` pass (10 passed), black clean.

## Screenshots (if appropriate)

N/A

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
