### PR TITLE
Skip scheduled DockerHub publish workflow on forks

### DIFF
--- a/.github/workflows/docker-hub-image-publish.yml
+++ b/.github/workflows/docker-hub-image-publish.yml
@@ -25,6 +25,7 @@ env:
 jobs:
   publish:
     name: Publish Docker Image to DockerHub
+    if: ${{ github.repository == 'spotDL/spotify-downloader' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/docker-hub-image-publish.yml
+++ b/.github/workflows/docker-hub-image-publish.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   publish:
     name: Publish Docker Image to DockerHub
-    if: ${{ github.repository == 'spotDL/spotify-downloader' }}
+    if: ${{ github.event_name != 'schedule' || github.repository == 'spotDL/spotify-downloader' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
## What

Adds a repository guard to the `publish` job in the DockerHub publish workflow:

```yaml
if: ${{ github.repository == 'spotDL/spotify-downloader' }}
```

## Why

The workflow has a nightly `schedule` trigger. Forks copy the workflow file, so any fork with Actions enabled runs the cron every night — and fails (forks lack a `dev` branch and the DockerHub secrets). Example: https://github.com/bolshoytoster/spotify-downloader/actions/runs/30599844308

Since scheduled runs are attributed to the last committer of the workflow file, these fork failures also generate notification noise for spotDL maintainers.

With this guard the job skips instantly on forks instead of failing. No behaviour change for the main repository.