### PR TITLE
azlyrics: fix redirect loop and fail fast on the bot-check interstitial

### DIFF
--- a/spotdl/providers/lyrics/azlyrics.py
+++ b/spotdl/providers/lyrics/azlyrics.py
@@ -26,10 +26,9 @@ class AzLyrics(LyricsProvider):
         self.session = requests.Session()
         # No User-Agent override: AZLyrics traps requests claiming to be a
         # browser in a redirect loop, while requests' default UA is served
-        # normally (see #2682).
+        # normally (see #2682). A `Host` header also causes a redirect loop.
         self.session.headers.update(
             {
-                "Host": "www.azlyrics.com",
                 "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
                 "Accept-Language": "en-US,en;q=0.5",
                 "Accept-Encoding": "gzip, deflate, br, zstd",

--- a/spotdl/providers/lyrics/azlyrics.py
+++ b/spotdl/providers/lyrics/azlyrics.py
@@ -45,6 +45,24 @@ class AzLyrics(LyricsProvider):
 
         self.x_code = None
 
+    @staticmethod
+    def _blocked(text: str, url: str) -> bool:
+        """Return True when AZLyrics answered with its bot-check interstitial.
+
+        AZLyrics now answers requests from flagged networks with a
+        "request for access" page (redirecting to the b.azlyrics.com
+        subnet) instead of real content. Detect it so we fail fast
+        instead of retrying a page that contains no results.
+        """
+        if "b.azlyrics.com" in url:
+            return True
+        low = text.lower() if text else ""
+        return (
+            "request for access" in low
+            or "detected unusual activity" in low
+            or "az_unblock" in low
+        )
+
     def get_results(self, name: str, artists: List[str], **_) -> Dict[str, str]:
         """
         Returns the results for the given song.
@@ -133,6 +151,12 @@ class AzLyrics(LyricsProvider):
         """
 
         response = self.session.get(url)
+        if self._blocked(response.text, response.url):
+            logger.debug(
+                "AZLyrics: bot-check interstitial present on lyrics page (%s).",
+                response.url,
+            )
+            return None
         soup = BeautifulSoup(response.content, "html.parser")
 
         # Find all divs that don't have a class
@@ -159,7 +183,13 @@ class AzLyrics(LyricsProvider):
         js_code = None
 
         try:
-            self.session.get("https://www.azlyrics.com/")
+            home = self.session.get("https://www.azlyrics.com/")
+            if self._blocked(home.text, home.url):
+                logger.debug(
+                    "AZLyrics: bot-check interstitial present (%s), aborting.",
+                    home.url,
+                )
+                return None
 
             resp = self.session.get("https://www.azlyrics.com/geo.js")
             js_code = resp.text

--- a/tests/providers/lyrics/test_azlyrics.py
+++ b/tests/providers/lyrics/test_azlyrics.py
@@ -1,17 +1,28 @@
-# import pytest
-# from rapidfuzz import fuzz
-
-# from spotdl.providers.lyrics.azlyrics import AzLyrics
-
-# lyrics = "Always think about you\nAlways thought I have a life I could grow with you\nAs time fades, crazy how our lifes changed\nFeeling like a shockwave without you\n\nAlways think about you\nAlways thought I have a life I could grow with you\nAs time fades, crazy how our lifes changed\nFeeling like a shockwave without you\n\nAlways think about you\nAlways thought I have a life I could grow with you\nBut as time fades, crazy how our lifes changed\nFeeling like a shockwave without you\n\nFeeling like a shockwave, shockwave, shockwave, shockwave, shockwave, shockwave, shockwave, shockwave, shockwave\n\nFeeling like this shockwave\nGet out of this shockwave\n\nShockwave without you\nShockwave without you\n\nAlways think about you\nAlways thought I have a life I could grow with you\nAs time fades, crazy how our lifes changed\nFeeling like a shockwave without you\n\nAlways think about you\nAlways thought I have a life I could grow with you\nBut as time fades, crazy how our lifes changed\nFeeling like a shockwave without you\n\nAlways think about you\nAlways thought I have a life I could grow with you\nBut as time fades, crazy how our lifes changed\nFeeling like a shockwave without you\n\nFeeling like a shockwave, shockwave, shockwave, shockwave, shockwave, shockwave, shockwave, shockwave, shockwave\n\nFeeling like this shockwave\nGet out of this shockwave\n"
+from spotdl.providers.lyrics.azlyrics import AzLyrics
 
 
-# @pytest.mark.vcr()
-# def test_get_azlyrics_lyrics():
-#     azlyrics = AzLyrics()
+def test_azlyrics_blocked_detection():
+    azlyrics = AzLyrics()
 
-#     result = azlyrics.get_lyrics("Shockwave", ["Marshmello"])
+    # real content from a healthy page must not be flagged
+    assert azlyrics._blocked(
+        "<html><body><div>lyrics here</div></body></html>",
+        "https://www.azlyrics.com/lyrics/artist/song.html",
+    ) is False
 
-#     assert result is not None
+    # the "request for access" interstitial
+    assert azlyrics._blocked(
+        "<title>AZLyrics - request for access</title>",
+        "https://www.azlyrics.com/search/",
+    ) is True
 
-#     assert fuzz.ratio(result, lyrics) > 80
+    # unusual activity message
+    assert azlyrics._blocked(
+        "Our systems have detected unusual activity from your IP address",
+        "https://www.azlyrics.com/lyrics/artist/song.html",
+    ) is True
+
+    # redirect to the anti-bot b.azlyrics.com subnet
+    assert azlyrics._blocked(
+        "", "https://b.azlyrics.com/?u=/search/"
+    ) is True


### PR DESCRIPTION
azlyrics: fix redirect loop and fail fast on the bot-check interstitial

## Description
Two small fixes to the AZLyrics provider:

1. Drop the `Host` header from the session (it forces every request into a redirect loop).
2. Detect the anti-bot "request for access" interstitial and skip the provider early instead of burning several requests on search + `geo.js` that return the wall page (with no real `x_code` in it).

The bot wall is currently served to a portion of users (flagged IP ranges/geo), and the redirect loop was reproducible everywhere, so both were wasting a handful of requests on every song.

The provider test was fully commented out; this re-enables it with deterministic unit tests for the interstitial detection (no network, no cassette).

## Related Issue
Refs #2572 — one of the three default lyric providers is broken; this hardens AZLyrics (the other two are tracked in #2668 / #2741).

## Motivation and Context
Since the v4.5 cycle, lyric embedding has been broken out of the box. This is a self-contained piece of it: the AZLyrics provider both misbehaves (redirect loop) and, when it does reach the site, gets served a wall that has no usable content.

## How Has This Been Tested?
- `Host`-header removal verified against the live site with `curl` (the request stops redirect-looping).
- Interstitial detection unit-tested (the `request for access` page, the "unusual activity" message, and the `b.azlyrics.com` redirect are all caught; a healthy page is not).
- From a network behind the bot wall, the provider now bails on the first response instead of spending several requests extracting an `x_code` from the wall HTML (observed in `--log-level DEBUG`).
- `pytest tests/providers/lyrics/test_azlyrics.py` passes.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project (black, isort, mypy, pylint pass on the touched files)
- [ ] My change requires a change to the documentation
- [ ] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
