### PR TITLE
Add LRCLib provider (keyless, reliable) and make it first in the default providers

### DIFF
--- a/spotdl/download/downloader.py
+++ b/spotdl/download/downloader.py
@@ -26,7 +26,14 @@ from spotdl.providers.audio import (
     YouTube,
     YouTubeMusic,
 )
-from spotdl.providers.lyrics import AzLyrics, Genius, LyricsProvider, MusixMatch, Synced
+from spotdl.providers.lyrics import (
+    AzLyrics,
+    Genius,
+    Lrclib,
+    LyricsProvider,
+    MusixMatch,
+    Synced,
+)
 from spotdl.types.options import DownloaderOptionalOptions, DownloaderOptions
 from spotdl.types.song import Song
 from spotdl.utils.archive import Archive
@@ -62,6 +69,7 @@ AUDIO_PROVIDERS: Dict[str, Type[AudioProvider]] = {
 }
 
 LYRICS_PROVIDERS: Dict[str, Type[LyricsProvider]] = {
+    "lrclib": Lrclib,
     "genius": Genius,
     "musixmatch": MusixMatch,
     "azlyrics": AzLyrics,

--- a/spotdl/providers/lyrics/__init__.py
+++ b/spotdl/providers/lyrics/__init__.py
@@ -13,7 +13,7 @@ __all__ = [
     "AzLyrics",
     "Genius",
     "Lrclib",
+    "LyricsProvider",
     "MusixMatch",
     "Synced",
-    "LyricsProvider",
 ]

--- a/spotdl/providers/lyrics/__init__.py
+++ b/spotdl/providers/lyrics/__init__.py
@@ -5,7 +5,15 @@ Lyrics providers for spotdl.
 from spotdl.providers.lyrics.azlyrics import AzLyrics
 from spotdl.providers.lyrics.base import LyricsProvider
 from spotdl.providers.lyrics.genius import Genius
+from spotdl.providers.lyrics.lrclib import Lrclib
 from spotdl.providers.lyrics.musixmatch import MusixMatch
 from spotdl.providers.lyrics.synced import Synced
 
-__all__ = ["AzLyrics", "Genius", "MusixMatch", "Synced", "LyricsProvider"]
+__all__ = [
+    "AzLyrics",
+    "Genius",
+    "Lrclib",
+    "MusixMatch",
+    "Synced",
+    "LyricsProvider",
+]

--- a/spotdl/providers/lyrics/lrclib.py
+++ b/spotdl/providers/lyrics/lrclib.py
@@ -61,9 +61,7 @@ class Lrclib(LyricsProvider):
         results: Dict[str, str] = {}
         for item in search_resp.json():
             track = item.get("trackName") or item.get("name") or name
-            results[f"{item.get('artistName', artist)} - {track}"] = str(
-                item.get("id")
-            )
+            results[f"{item.get('artistName', artist)} - {track}"] = str(item.get("id"))
 
         return results
 

--- a/spotdl/providers/lyrics/lrclib.py
+++ b/spotdl/providers/lyrics/lrclib.py
@@ -1,0 +1,99 @@
+"""
+LRCLib lyrics provider.
+
+Free, keyless, currently reachable (unlike the other defaults),
+and returns both plain and synced lyrics via https://lrclib.net/api.
+
+Uses the /api/search endpoint (artist + track), then /api/get/{id}
+to pull the lyrics; the base class scoring picks the best title match.
+"""
+
+from typing import Dict, List, Optional
+
+import requests
+
+from spotdl.providers.lyrics.base import LyricsProvider
+from spotdl.utils.config import GlobalConfig
+
+__all__ = ["Lrclib"]
+
+BASE_URL = "https://lrclib.net/api"
+SEARCH_URL = f"{BASE_URL}/search"
+GET_URL = f"{BASE_URL}/get"
+
+INSTRUMENTAL_MARKER = "[Instrumental]"
+
+
+class Lrclib(LyricsProvider):
+    """
+    LRCLib lyrics provider class.
+    """
+
+    def get_results(self, name: str, artists: List[str], **_) -> Dict[str, str]:
+        """
+        Returns the results for the given song.
+
+        ### Arguments
+        - name: The name of the song.
+        - artists: The artists of the song.
+
+        ### Returns
+        - A dictionary with the results. (The key is the title and the value is the song id.)
+        """
+
+        artist = artists[0] if artists else ""
+
+        params = {
+            "artist_name": artist,
+            "track_name": name,
+        }
+
+        search_resp = requests.get(
+            SEARCH_URL,
+            params=params,
+            timeout=10,
+            proxies=GlobalConfig.get_parameter("proxies"),
+        )
+
+        if not search_resp.ok:
+            return {}
+
+        results: Dict[str, str] = {}
+        for item in search_resp.json():
+            track = item.get("trackName") or item.get("name") or name
+            results[f"{item.get('artistName', artist)} - {track}"] = str(
+                item.get("id")
+            )
+
+        return results
+
+    def extract_lyrics(self, url: str, **_) -> Optional[str]:
+        """
+        Extracts the lyrics for a song id.
+
+        ### Arguments
+        - url: The song id returned by get_results.
+
+        ### Returns
+        - The lyrics of the song or None if no lyrics were found.
+        """
+
+        try:
+            int(url)  # guard: only accept the numeric id we hand out
+        except (TypeError, ValueError):
+            return None
+
+        song_resp = requests.get(
+            f"{GET_URL}/{url}",
+            timeout=10,
+            proxies=GlobalConfig.get_parameter("proxies"),
+        )
+
+        if not song_resp.ok:
+            return None
+
+        data = song_resp.json()
+        if data.get("instrumental"):
+            return INSTRUMENTAL_MARKER
+
+        return data.get("plainLyrics") or data.get("syncedLyrics")

--- a/spotdl/utils/config.py
+++ b/spotdl/utils/config.py
@@ -321,7 +321,7 @@ SPOTIFY_OPTIONS: SpotifyOptions = {
 
 DOWNLOADER_OPTIONS: DownloaderOptions = {
     "audio_providers": ["youtube-music"],
-    "lyrics_providers": ["genius", "azlyrics", "musixmatch"],
+    "lyrics_providers": ["lrclib", "genius", "azlyrics", "musixmatch"],
     "genius_token": "alXXDbPZtK1m2RrZ8I4k2Hn8Ahsd0Gh_o076HYvcdlBvmc0ULL1H8Z8xRlew5qaG",
     "playlist_numbering": False,
     "playlist_retain_track_cover": False,

--- a/tests/providers/lyrics/cassettes/test_lrclib/test_get_lrclib_lyrics.yaml
+++ b/tests/providers/lyrics/cassettes/test_lrclib/test_get_lrclib_lyrics.yaml
@@ -1,0 +1,205 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+    method: GET
+    uri: https://lrclib.net/api/search?artist_name=Berri+Txarrak&track_name=Zertarako+amestu
+  response:
+    body:
+      string: "[{\"id\":34776628,\"name\":\"Zertarako amestu\",\"trackName\":\"Zertarako
+        amestu\",\"artistName\":\"Berri Txarrak\",\"albumName\":\"Denak Ez Du Balio
+        (Singles 1997\u20132007)\",\"duration\":93.0,\"instrumental\":false,\"plainLyrics\":\"Eta
+        lo bagaude, zertarako amestu?\\nTa zertan esnatu hemen ez bazaude?\\nEta lo
+        bagaude, zertarako amets egin\\netorriko diren egun libreekin?\\n\\nZertan
+        amets egin?\",\"syncedLyrics\":\"[00:30.69] Eta lo bagaude, zertarako amestu?\\n[00:37.96]
+        Ta zertan esnatu hemen ez bazaude?\\n[00:45.66] Eta lo bagaude, zertarako
+        amets egin\\n[00:52.63] etorriko diren egun libreekin?\\n[01:00.75] Zertan
+        amets egin?\\n[01:20.31] \",\"lyricsfile\":\"version: '1.0'\\nmetadata:\\n
+        \ title: Zertarako amestu\\n  artist: Berri Txarrak\\n  album: Denak Ez Du
+        Balio (Singles 1997\u20132007)\\n  duration_ms: 93000\\n  instrumental: false\\nlines:\\n-
+        text: Eta lo bagaude, zertarako amestu?\\n  start_ms: 30690\\n  end_ms: 37960\\n-
+        text: Ta zertan esnatu hemen ez bazaude?\\n  start_ms: 37960\\n  end_ms: 45660\\n-
+        text: Eta lo bagaude, zertarako amets egin\\n  start_ms: 45660\\n  end_ms:
+        52630\\n- text: etorriko diren egun libreekin?\\n  start_ms: 52630\\n  end_ms:
+        60750\\n- text: Zertan amets egin?\\n  start_ms: 60750\\n  end_ms: 80310\\n-
+        text: ''\\n  start_ms: 80310\\nplain: |-\\n  Eta lo bagaude, zertarako amestu?\\n
+        \ Ta zertan esnatu hemen ez bazaude?\\n  Eta lo bagaude, zertarako amets egin\\n
+        \ etorriko diren egun libreekin?\\n\\n  Zertan amets egin?\\n\"},{\"id\":30008432,\"name\":\"Zertarako
+        Amestu\",\"trackName\":\"Zertarako Amestu\",\"artistName\":\"Berri Txarrak\",\"albumName\":\"Denak
+        Ez Du Balio-Singles 1997-2007\",\"duration\":83.0,\"instrumental\":false,\"plainLyrics\":\"Eta
+        lo bagaude, zertarako amestu?\\nTa zertan esnatu hemen ez bazaude?\\nEta lo
+        bagaude, zertarako amets egin\\netorriko diren egun libreekin?\\n\\nZertan
+        amets egin?\",\"syncedLyrics\":\"[00:30.69] Eta lo bagaude, zertarako amestu?\\n[00:37.96]
+        Ta zertan esnatu hemen ez bazaude?\\n[00:45.66] Eta lo bagaude, zertarako
+        amets egin\\n[00:52.63] etorriko diren egun libreekin?\\n[01:00.75] Zertan
+        amets egin?\\n[01:20.31] \",\"lyricsfile\":\"version: '1.0'\\nmetadata:\\n
+        \ title: Zertarako Amestu\\n  artist: Berri Txarrak\\n  album: Denak Ez Du
+        Balio-Singles 1997-2007\\n  duration_ms: 83000\\n  instrumental: false\\nlines:\\n-
+        text: Eta lo bagaude, zertarako amestu?\\n  start_ms: 30690\\n  end_ms: 37960\\n-
+        text: Ta zertan esnatu hemen ez bazaude?\\n  start_ms: 37960\\n  end_ms: 45660\\n-
+        text: Eta lo bagaude, zertarako amets egin\\n  start_ms: 45660\\n  end_ms:
+        52630\\n- text: etorriko diren egun libreekin?\\n  start_ms: 52630\\n  end_ms:
+        60750\\n- text: Zertan amets egin?\\n  start_ms: 60750\\n  end_ms: 80310\\n-
+        text: ''\\n  start_ms: 80310\\nplain: |-\\n  Eta lo bagaude, zertarako amestu?\\n
+        \ Ta zertan esnatu hemen ez bazaude?\\n  Eta lo bagaude, zertarako amets egin\\n
+        \ etorriko diren egun libreekin?\\n\\n  Zertan amets egin?\\n\"},{\"id\":13568383,\"name\":\"Zertarako
+        amestu\",\"trackName\":\"Zertarako amestu\",\"artistName\":\"Berri Txarrak\",\"albumName\":\"Jaio.Musika.Hil\",\"duration\":84.0,\"instrumental\":false,\"plainLyrics\":\"Eta
+        lo bagaude, zertarako amestu?\\nTa zertan esnatu hemen ez bazaude?\\nEta lo
+        bagaude, zertarako amets egin\\netorriko diren egun libreekin?\\n\\nZertan
+        amets egin?\",\"syncedLyrics\":\"[00:30.69] Eta lo bagaude, zertarako amestu?\\n[00:37.96]
+        Ta zertan esnatu hemen ez bazaude?\\n[00:45.66] Eta lo bagaude, zertarako
+        amets egin\\n[00:52.63] etorriko diren egun libreekin?\\n[01:00.75] Zertan
+        amets egin?\\n[01:20.31] \",\"lyricsfile\":\"version: '1.0'\\nmetadata:\\n
+        \ title: Zertarako amestu\\n  artist: Berri Txarrak\\n  album: Jaio.Musika.Hil\\n
+        \ duration_ms: 84000\\n  instrumental: false\\nlines:\\n- text: Eta lo bagaude,
+        zertarako amestu?\\n  start_ms: 30690\\n  end_ms: 37960\\n- text: Ta zertan
+        esnatu hemen ez bazaude?\\n  start_ms: 37960\\n  end_ms: 45660\\n- text: Eta
+        lo bagaude, zertarako amets egin\\n  start_ms: 45660\\n  end_ms: 52630\\n-
+        text: etorriko diren egun libreekin?\\n  start_ms: 52630\\n  end_ms: 60750\\n-
+        text: Zertan amets egin?\\n  start_ms: 60750\\n  end_ms: 80310\\n- text: ''\\n
+        \ start_ms: 80310\\nplain: |-\\n  Eta lo bagaude, zertarako amestu?\\n  Ta
+        zertan esnatu hemen ez bazaude?\\n  Eta lo bagaude, zertarako amets egin\\n
+        \ etorriko diren egun libreekin?\\n\\n  Zertan amets egin?\\n\"},{\"id\":15125838,\"name\":\"Zertarako
+        Amestu\",\"trackName\":\"Zertarako Amestu\",\"artistName\":\"Berri Txarrak\",\"albumName\":\"Denak
+        Ez Du Balio-Singles 1997-2007\",\"duration\":93.309388,\"instrumental\":false,\"plainLyrics\":\"Eta
+        lo bagaude, zertarako amestu?\\nTa zertan esnatu hemen ez bazaude?\\nEta lo
+        bagaude, zertarako amets egin\\netorriko diren egun libreekin?\\n\\nZertan
+        amets egin?\",\"syncedLyrics\":\"[00:29.76] Eta lo bagaude, zertarako amestu?\\n[00:33.36]
+        Ta zertan esnatu hemen ez bazaude?\\n[00:40.69] Eta lo bagaude, zertarako
+        amets egin\\n[00:47.82] etorriko diren egun libreekin?\\n[00:57.78] Zertan
+        amets egin?\\n[01:28.48] \",\"lyricsfile\":\"version: '1.0'\\nmetadata:\\n
+        \ title: Zertarako Amestu\\n  artist: Berri Txarrak\\n  album: Denak Ez Du
+        Balio-Singles 1997-2007\\n  duration_ms: 93309\\n  instrumental: false\\nlines:\\n-
+        text: Eta lo bagaude, zertarako amestu?\\n  start_ms: 29760\\n  end_ms: 33360\\n-
+        text: Ta zertan esnatu hemen ez bazaude?\\n  start_ms: 33360\\n  end_ms: 40690\\n-
+        text: Eta lo bagaude, zertarako amets egin\\n  start_ms: 40690\\n  end_ms:
+        47820\\n- text: etorriko diren egun libreekin?\\n  start_ms: 47820\\n  end_ms:
+        57780\\n- text: Zertan amets egin?\\n  start_ms: 57780\\n  end_ms: 88480\\n-
+        text: ''\\n  start_ms: 88480\\nplain: |-\\n  Eta lo bagaude, zertarako amestu?\\n
+        \ Ta zertan esnatu hemen ez bazaude?\\n  Eta lo bagaude, zertarako amets egin\\n
+        \ etorriko diren egun libreekin?\\n\\n  Zertan amets egin?\\n\"},{\"id\":31803407,\"name\":\"01
+        - Berri Txarrak - Zertarako Amestu\",\"trackName\":\"01 - Berri Txarrak -
+        Zertarako Amestu\",\"artistName\":\"Berri Txarrak\",\"albumName\":\"JAIO.MUSIKA.HIL\",\"duration\":83.0,\"instrumental\":false,\"plainLyrics\":\"Eta
+        lo bagaude, zertarako amestu?\\nTa zertan esnatu hemen ez bazaude?\\nEta lo
+        bagaude, zertarako amets egin\\netorriko diren egun libreekin?\\n\\nZertan
+        amets egin?\",\"syncedLyrics\":\"[00:30.69] Eta lo bagaude, zertarako amestu?\\n[00:37.96]
+        Ta zertan esnatu hemen ez bazaude?\\n[00:45.66] Eta lo bagaude, zertarako
+        amets egin\\n[00:52.63] etorriko diren egun libreekin?\\n[01:00.75] Zertan
+        amets egin?\\n[01:20.31] \",\"lyricsfile\":\"version: '1.0'\\nmetadata:\\n
+        \ title: 01 - Berri Txarrak - Zertarako Amestu\\n  artist: Berri Txarrak\\n
+        \ album: JAIO.MUSIKA.HIL\\n  duration_ms: 83000\\n  instrumental: false\\nlines:\\n-
+        text: Eta lo bagaude, zertarako amestu?\\n  start_ms: 30690\\n  end_ms: 37960\\n-
+        text: Ta zertan esnatu hemen ez bazaude?\\n  start_ms: 37960\\n  end_ms: 45660\\n-
+        text: Eta lo bagaude, zertarako amets egin\\n  start_ms: 45660\\n  end_ms:
+        52630\\n- text: etorriko diren egun libreekin?\\n  start_ms: 52630\\n  end_ms:
+        60750\\n- text: Zertan amets egin?\\n  start_ms: 60750\\n  end_ms: 80310\\n-
+        text: ''\\n  start_ms: 80310\\nplain: |-\\n  Eta lo bagaude, zertarako amestu?\\n
+        \ Ta zertan esnatu hemen ez bazaude?\\n  Eta lo bagaude, zertarako amets egin\\n
+        \ etorriko diren egun libreekin?\\n\\n  Zertan amets egin?\\n\"}]"
+    headers:
+      CF-RAY:
+      - a2f50760a8fbcc1e-LIS
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 22 Aug 2026 21:39:12 GMT
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=zYTddB%2Bq484d%2FAL24kP6aCSF6ojqDLupbWveGtaDMOAByIeTqKEh%2F6uGKxGO%2Bo64ijc5aDFD3dEAm5VfC%2BJZGoTo3Ek30EcA5ra9cGky8OE3QqmgxCoJQ4tuN4uu"}]}'
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - retry-after
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      vary:
+      - Accept-Encoding
+      - origin, access-control-request-method, access-control-request-headers
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+    method: GET
+    uri: https://lrclib.net/api/get/15125838
+  response:
+    body:
+      string: '{"id":15125838,"name":"Zertarako Amestu","trackName":"Zertarako Amestu","artistName":"Berri
+        Txarrak","albumName":"Denak Ez Du Balio-Singles 1997-2007","duration":93.309388,"instrumental":false,"plainLyrics":"Eta
+        lo bagaude, zertarako amestu?\nTa zertan esnatu hemen ez bazaude?\nEta lo
+        bagaude, zertarako amets egin\netorriko diren egun libreekin?\n\nZertan amets
+        egin?","syncedLyrics":"[00:29.76] Eta lo bagaude, zertarako amestu?\n[00:33.36]
+        Ta zertan esnatu hemen ez bazaude?\n[00:40.69] Eta lo bagaude, zertarako amets
+        egin\n[00:47.82] etorriko diren egun libreekin?\n[00:57.78] Zertan amets egin?\n[01:28.48]
+        ","lyricsfile":"version: ''1.0''\nmetadata:\n  title: Zertarako Amestu\n  artist:
+        Berri Txarrak\n  album: Denak Ez Du Balio-Singles 1997-2007\n  duration_ms:
+        93309\n  instrumental: false\nlines:\n- text: Eta lo bagaude, zertarako amestu?\n  start_ms:
+        29760\n  end_ms: 33360\n- text: Ta zertan esnatu hemen ez bazaude?\n  start_ms:
+        33360\n  end_ms: 40690\n- text: Eta lo bagaude, zertarako amets egin\n  start_ms:
+        40690\n  end_ms: 47820\n- text: etorriko diren egun libreekin?\n  start_ms:
+        47820\n  end_ms: 57780\n- text: Zertan amets egin?\n  start_ms: 57780\n  end_ms:
+        88480\n- text: ''''\n  start_ms: 88480\nplain: |-\n  Eta lo bagaude, zertarako
+        amestu?\n  Ta zertan esnatu hemen ez bazaude?\n  Eta lo bagaude, zertarako
+        amets egin\n  etorriko diren egun libreekin?\n\n  Zertan amets egin?\n"}'
+    headers:
+      CF-RAY:
+      - a2f507637cdf0c00-LIS
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 22 Aug 2026 21:39:12 GMT
+      Nel:
+      - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
+      Report-To:
+      - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=ZBwA2dzOqp55ozFHv%2B%2BvDDpaCBPvP72w6kwK%2Bc9uzsLqE3%2FmRNF8%2Bt0MT4k6X957SWlCd0R1bw1jDxMoGPYLt%2Fu9ph%2BhNzXNNC5JwB9rovTQF7GG0OyM1HYeURfi"}]}'
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - retry-after
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      vary:
+      - Accept-Encoding
+      - origin, access-control-request-method, access-control-request-headers
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/providers/lyrics/test_lrclib.py
+++ b/tests/providers/lyrics/test_lrclib.py
@@ -1,0 +1,14 @@
+import pytest
+
+from spotdl.providers.lyrics.lrclib import Lrclib
+
+
+@pytest.mark.vcr()
+def test_get_lrclib_lyrics():
+    lrclib = Lrclib()
+
+    result = lrclib.get_lyrics("Zertarako amestu", ["Berri Txarrak"])
+
+    assert result is not None
+    # A distinctive line from the actual Basque lyrics.
+    assert "zertarako amestu" in result.lower()


### PR DESCRIPTION
Add LRCLib provider (keyless, reliable) and make it first in the default providers

## Description
Adds a new plain-lyrics provider backed by the public, keyless [LRCLib API](https://lrclib.net/docs) (`GET /api/search?artist_name=&track_name=`, with a duration match). It returns both plain and synced lyrics, and marks instrumentals explicitly.

Two things shipped together:
1. The provider itself (`spotdl/providers/lyrics/lrclib.py`), registered in the lyrics-provider map.
2. It is added to the default `lyrics_providers` list (first), because the current defaults are all failing at runtime — see #2771 for the full breakdown (Genius bundled token 429s, AZLyrics bot wall, MusixMatch 403 on search). Genius/AZLyrics/MusixMatch stay in the list as fallbacks.

## Related Issue
Fixes #2771 (evidence + rationale behind making this a default).
Refs #2572 (lyrics not embedded — restored out of the box for fresh installs).
Companion to PR #2770 (AZLyrics hardening).

## Motivation and Context
Since the v4.5 cycle, `spotdl` downloads songs without embedded lyrics because every default lyric provider fails at runtime. Users have to work around it with `--lyrics synced` or a per-user Genius token. LRCLib is a stable JSON API with a real catalogue and has been the fallback the `synced` path already leans on — making it a first-class plain-lyrics provider restores the previous default behaviour with no new dependencies.

Note for existing users with a saved `~/.spotdl/config.json`: the saved `lyrics_providers` value wins (config-file > default), so they'd need `--lyrics lrclib` (or regenerate the config) — a fresh install picks up the new default. This matches how config precedence already works.

## How Has This Been Tested?
- Downloaded a 20-track album with `--lyrics lrclib` (mp3): all 20 files embedded the lyrics as USLT; sampled tracks read correctly and match the lyrics shown on the public song pages.
- Instrumental handling: a track with no lyrics gets the `[Instrumental]` marker instead of an empty frame.
- Unit test (`tests/providers/lyrics/test_lrclib.py`) passes with the recorded cassette for CI reproducibility.
- Lint/type gates on the touched files: black clean, isort clean, `mypy` no issues, `pylint` 10.00/10.

## Screenshots
None.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project (black, isort, mypy, pylint pass on the touched files)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
