### PR TITLE
Add default YouTube fallback for audio search

### DIFF
--- a/spotdl/utils/config.py
+++ b/spotdl/utils/config.py
@@ -320,7 +320,7 @@ SPOTIFY_OPTIONS: SpotifyOptions = {
 }
 
 DOWNLOADER_OPTIONS: DownloaderOptions = {
-    "audio_providers": ["youtube-music"],
+    "audio_providers": ["youtube-music", "youtube"],
     "lyrics_providers": ["genius", "azlyrics", "musixmatch"],
     "genius_token": "alXXDbPZtK1m2RrZ8I4k2Hn8Ahsd0Gh_o076HYvcdlBvmc0ULL1H8Z8xRlew5qaG",
     "playlist_numbering": False,

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -93,3 +93,13 @@ def test_use_official_api_argument_overrides_config():
     )
 
     assert settings["use_official_api"] is True
+
+
+def test_default_audio_providers_include_youtube_fallback():
+    """
+    Tests that downloads prefer YouTube Music but fall back to YouTube by default.
+    """
+
+    settings = create_settings_type(SimpleNamespace(), {}, DOWNLOADER_OPTIONS)
+
+    assert settings["audio_providers"] == ["youtube-music", "youtube"]

--- a/tests/utils/test_downloader.py
+++ b/tests/utils/test_downloader.py
@@ -1,3 +1,5 @@
+from spotdl.download.downloader import Downloader
+from spotdl.types.song import Song
 from spotdl.utils.downloader import check_ytmusic_connection
 
 
@@ -8,3 +10,50 @@ def test_check_ytmusic_connection_suppresses_empty_search_log(mocker):
 
     assert check_ytmusic_connection() is False
     ytm.get_results.assert_called_once_with("a", log_search_failures=False)
+
+
+def test_search_falls_back_to_next_audio_provider(mocker):
+    first_provider = mocker.Mock()
+    first_provider.name = "youtube-music"
+    first_provider.search.return_value = None
+
+    second_provider = mocker.Mock()
+    second_provider.name = "youtube"
+    second_provider.search.return_value = "https://www.youtube.com/watch?v=test"
+
+    downloader = Downloader({"audio_providers": ["youtube-music", "youtube"]})
+    downloader.audio_providers = [first_provider, second_provider]
+
+    song = Song.from_dict(
+        {
+            "name": "The Talented Mr. Tripley",
+            "artists": ["DJ Koze"],
+            "artist": "DJ Koze",
+            "album_id": "test-album",
+            "album_name": "Music Can Hear Us",
+            "album_artist": "DJ Koze",
+            "album_type": "album",
+            "genres": [],
+            "disc_number": 1,
+            "disc_count": 1,
+            "duration": 327,
+            "year": 2024,
+            "date": "2024-04-05",
+            "track_number": 1,
+            "tracks_count": 1,
+            "isrc": "TESTISRC12345",
+            "song_id": "test-song",
+            "cover_url": "https://example.com/cover.jpg",
+            "explicit": False,
+            "publisher": "Pampa",
+            "url": "https://open.spotify.com/track/test-song",
+            "copyright_text": "2024 Pampa Records",
+            "download_url": None,
+        }
+    )
+
+    result = downloader.search(song)
+
+    assert result == "https://www.youtube.com/watch?v=test"
+    first_provider.search.assert_called_once_with(song, False)
+    second_provider.search.assert_called_once_with(song, False)


### PR DESCRIPTION
Summary: add plain YouTube as the default fallback after YouTube Music, preserve YouTube Music as the first-choice provider, and add regression coverage for the default provider list and provider fallback behavior. Why: some tracks return no usable YouTube Music matches even when they are available on YouTube, so spotdl currently raises a lookup failure by default even though provider fallback already exists in Downloader.search. Testing: uv run pytest tests/utils/test_downloader.py::test_search_falls_back_to_next_audio_provider tests/utils/test_config.py::test_default_audio_providers_include_youtube_fallback.