### PR TITLE
docs: update byzanz link to GNOME GitLab

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -200,7 +200,7 @@ Enhancement suggestions are tracked as
   steps or point out the part which the suggestion is related to. You can use
   [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and
   [this tool](https://github.com/colinkeenan/silentcast) or
-  [this tool](https://github.com/GNOME/byzanz) on Linux.
+  [this tool](https://gitlab.gnome.org/GNOME/byzanz) on Linux.
       <!-- this should only be included if the project has a GUI -->
 - **Explain why this enhancement would be useful** to most spotdl users. You may also want to
   point out the other projects that solved it better and which could serve as inspiration.


### PR DESCRIPTION
The Linux GIF-recording tool link in CONTRIBUTING pointed to `github.com/GNOME/byzanz`, which returns 404 — GNOME development has moved off GitHub. Updated the link to the official repository at `gitlab.gnome.org/GNOME/byzanz` (verified resolving correctly).